### PR TITLE
Introduces elemental tags (air, earth, fire, and water), the magus class tag, as well as a number of new spells

### DIFF
--- a/spells.yml
+++ b/spells.yml
@@ -337,7 +337,7 @@ arcane_weapon:
   concentration: true
   description: |-
     You channel arcane energy into one weapon you're holding, and choose one damage type: acid, cold, fire, lightning, poison, or thunder. Until the spell ends, you deal an extra 1d4 damage of the chosen type to any target you hit with the weapon.
-  duration: up to 1 hour
+  duration: Up to 1 hour
   higher_level: When you cast this spell using a spell slot of 3rd level or higher, you can maintain your concentration on the spell for up to 8 hours.
   level: 1
   material: a weapon
@@ -2524,6 +2524,23 @@ divine_favor:
   tags:
     - evocation
     - paladin
+divine_smite:
+  casting_time: 1 free action, which you take when you hit with a melee weapon attack
+  components: V
+  concentration: false
+  description: |-
+    Your weapon shines with divine energy as you strike. The target takes 2d8 radiant damage, or 3d8 if it is a Fiend or Undead.
+  duration: Instantaneous
+  higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.
+  level: 1
+  name: Divine Smite
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - evocation
+    - paladin
+    - smite
 divine_word:
   casting_time: 1 minor action
   components: V
@@ -2881,6 +2898,23 @@ eldritch_blast:
   tags:
     - evocation
     - warlock
+eldritch_smite:
+  casting_time: 1 free action, which you take when you hit with a weapon attack
+  components: V
+  concentration: false
+  description: |-
+    Your weapon hums with eldritch power, and the target takes 4d8 force damage. If it is Huge or smaller, you may also knock it prone.
+  duration: Instantaneous
+  higher_level: If you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d8 for each slot level above 1st.
+  level: 3
+  name: Eldritch Smite
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - evocation
+    - warlock
+    - smite
 elemental_bane:
   casting_time: 1 standard action
   components: V, S
@@ -3874,7 +3908,7 @@ frost_strike:
   concentration: false
   description: |-
     The air chills around your weapon. The target takes 1d6 cold damage, and you gain temporary hit points equal to the cold damage rolled for the duration of the spell.
-  duration: up to 1 minute
+  duration: Up to 1 minute
   higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
   level: 1
   name: Frost Strike
@@ -4249,7 +4283,7 @@ grim_apparitions:
     When you cast this spell, you can designate any number of creatures you can see to be unaffected by it. An affected creature can't regain hit points while in the area, and when the creature enters the area for the first time on a turn or starts its turn there, it must make a Wisdom saving throw. On a failed save, it loses all of its temporary hit points.
   duration: Up to 1 minute
   level: 3
-  name: Spirit Shroud
+  name: Grim Apparitions
   range: Self
   sources:
     - TCE
@@ -7326,7 +7360,7 @@ rime_blade:
     You brandish the weapon used in the spell's casting and make a melee attack with it against one creature within reach. On a hit, the target suffers the weapon attack's normal effects and then becomes chilled by the icy blow. The creature's movement speed is reduced by 10 feet until the end of your next turn. This chill can spread to one creature of your choice within 5 feet of the target, also reducing their movement speed in the same way.
 
     This spell's damage increases when you reach certain levels. At 5th level, the melee attack deals an extra 1d8 cold damage to the target on a hit. The damage increases by 1d8 at 11th level (2d8) and again at 17th level (3d8).
-  duration: up to 1 round
+  duration: Up to 1 round
   level: 0
   material: a weapon
   name: Rime Blade
@@ -7434,7 +7468,7 @@ sapping_strike:
   concentration: false
   description: |-
     You wreath your weapon in necrotic energy. The target takes 1d6 necrotic damage and must then make a Constitution saving throw. On a failure, the target is slowed until the end of your next turn. Constructs and Undead are immune to the slowed condition inflicted by this spell.
-  duration: up to 1 round
+  duration: Up to 1 round
   higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
   level: 1
   name: Sapping Strike
@@ -8778,7 +8812,7 @@ telekinetic_grip:
     You attempt to bind a creature with telekinetic force. The target must succeed on a Strength saving throw or be pulled to an unoccupied space within 5 feet of you and be slowed until the start of your next turn.
 
     If the target is willing, they may forgo the saving throw and not be subjected to the slowed condition.
-  duration: up to 1 round
+  duration: Up to 1 round
   level: 1
   name: Telekinetic Grip
   range: Self

--- a/spells.yml
+++ b/spells.yml
@@ -13,16 +13,16 @@ absorb_elements:
     - XGE
   tags:
     - abjuration
+    - air
     - artificer
     - druid
+    - earth
+    - fire
     - magus
     - ranger
     - sorcerer
-    - wizard
-    - air
-    - earth
-    - fire
     - water
+    - wizard
 acid_arrow:
   casting_time: 1 standard action
   components: V, S, M
@@ -77,8 +77,8 @@ aid:
     - artificer
     - bard
     - cleric
-    - paladin
     - magus
+    - paladin
     - ranger
 alarm:
   casting_time: 1 minute
@@ -123,9 +123,9 @@ alter_self:
     - PHB
   tags:
     - artificer
-    - transmutation
     - magus
     - sorcerer
+    - transmutation
     - wizard
 animal_friendship:
   casting_time: 1 standard action
@@ -335,8 +335,7 @@ arcane_weapon:
   casting_time: 1 minor action
   components: V, S, M
   concentration: true
-  description: |-
-    You channel arcane energy into one weapon you're holding, and choose one damage type: acid, cold, fire, lightning, poison, or thunder. Until the spell ends, you deal an extra 1d4 damage of the chosen type to any target you hit with the weapon.
+  description: 'You channel arcane energy into one weapon you''re holding, and choose one damage type: acid, cold, fire, lightning, poison, or thunder. Until the spell ends, you deal an extra 1d4 damage of the chosen type to any target you hit with the weapon.'
   duration: Up to 1 hour
   higher_level: When you cast this spell using a spell slot of 3rd level or higher, you can maintain your concentration on the spell for up to 8 hours.
   level: 1
@@ -346,12 +345,12 @@ arcane_weapon:
   sources:
     - 2D
   tags:
-    - transmutation
-    - artificer
-    - magus
     - air
+    - artificer
     - earth
     - fire
+    - magus
+    - transmutation
     - water
 armor_of_ice:
   casting_time: 1 standard action
@@ -549,8 +548,8 @@ banishing_smite:
     - 2D
   tags:
     - abjuration
-    - paladin
     - magus
+    - paladin
     - smite
 banishment:
   casting_time: 1 standard action
@@ -573,8 +572,8 @@ banishment:
   tags:
     - abjuration
     - cleric
-    - paladin
     - magus
+    - paladin
     - sorcerer
     - warlock
     - wizard
@@ -684,8 +683,8 @@ binding_ice:
     - evocation
     - magus
     - sorcerer
-    - wizard
     - water
+    - wizard
 blade_barrier:
   casting_time: 1 standard action
   components: V, S
@@ -746,8 +745,7 @@ blazing_strike:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
   concentration: false
-  description: |-
-    Fire erupts from your weapon. The target, as well as each other creature of your choice within 10 feet of it, takes 1d6 fire damage.
+  description: Fire erupts from your weapon. The target, as well as each other creature of your choice within 10 feet of it, takes 1d6 fire damage.
   duration: Instantaneous
   higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
   level: 1
@@ -757,9 +755,9 @@ blazing_strike:
     - 2D
   tags:
     - evocation
+    - fire
     - magus
     - smite
-    - fire
 bless:
   casting_time: 1 standard action
   components: V, S, M
@@ -850,9 +848,9 @@ blink:
     - PHB
   tags:
     - artificer
+    - magus
     - sorcerer
     - transmutation
-    - magus
     - wizard
 blur:
   casting_time: 1 standard action
@@ -868,8 +866,8 @@ blur:
   tags:
     - artificer
     - illusion
-    - sorcerer
     - magus
+    - sorcerer
     - wizard
 bones_of_the_earth:
   casting_time: 1 standard action
@@ -891,8 +889,8 @@ bones_of_the_earth:
     - XGE
   tags:
     - druid
-    - transmutation
     - earth
+    - transmutation
 booming_blade:
   casting_time: 1 standard action
   components: S, M
@@ -909,13 +907,13 @@ booming_blade:
   sources:
     - TCE
   tags:
+    - air
     - artificer
     - evocation
     - magus
     - sorcerer
     - warlock
     - wizard
-    - air
 branding_smite:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
@@ -950,10 +948,10 @@ burning_hands:
     - PHB
   tags:
     - evocation
+    - fire
     - magus
     - sorcerer
     - wizard
-    - fire
 call_lightning:
   casting_time: 1 standard action
   components: V, S
@@ -971,9 +969,9 @@ call_lightning:
     - PHB (Errata 2.0)
     - 2D
   tags:
+    - air
     - conjuration
     - druid
-    - air
     - fire
 calm_emotions:
   casting_time: 1 standard action
@@ -1083,11 +1081,11 @@ chain_lightning:
   sources:
     - PHB
   tags:
+    - air
     - evocation
+    - fire
     - sorcerer
     - wizard
-    - air
-    - fire
 chaos_bolt:
   casting_time: 1 standard action
   components: V, S
@@ -1192,14 +1190,14 @@ chromatic_orb:
   sources:
     - PHB
   tags:
-    - evocation
-    - magus
-    - sorcerer
-    - wizard
     - air
     - earth
+    - evocation
     - fire
+    - magus
+    - sorcerer
     - water
+    - wizard
 circle_of_death:
   casting_time: 1 standard action
   components: V, S, M
@@ -1271,8 +1269,8 @@ cloak_of_shadow:
   sources:
     - XGE
   tags:
-    - necromancy
     - magus
+    - necromancy
     - warlock
 clone:
   casting_time: 1 hour
@@ -1509,12 +1507,12 @@ cone_of_cold:
     - PHB
     - TCE
   tags:
+    - air
     - druid
     - evocation
     - magus
     - sorcerer
     - wizard
-    - air
 confusion:
   casting_time: 1 standard action
   components: V, S, M
@@ -1688,10 +1686,10 @@ control_flames:
     - XGE
   tags:
     - druid
+    - fire
     - sorcerer
     - transmutation
     - wizard
-    - fire
 control_water:
   casting_time: 1 standard action
   components: V, S, M
@@ -1719,8 +1717,8 @@ control_water:
     - cleric
     - druid
     - transmutation
-    - wizard
     - water
+    - wizard
 control_weather:
   casting_time: 10 minutes
   components: V, S, M
@@ -1767,12 +1765,12 @@ control_weather:
   sources:
     - PHB
   tags:
+    - air
     - cleric
     - druid
     - transmutation
-    - wizard
-    - air
     - water
+    - wizard
 control_winds:
   casting_time: 1 standard action
   components: V, S
@@ -1793,11 +1791,11 @@ control_winds:
     - EEPC
     - XGE
   tags:
+    - air
     - druid
     - sorcerer
     - transmutation
     - wizard
-    - air
 cordon_of_arrows:
   casting_time: 1 standard action
   components: V, S, M
@@ -1855,11 +1853,11 @@ create_bonfire:
     - artificer
     - conjuration
     - druid
+    - fire
     - magus
     - sorcerer
     - warlock
     - wizard
-    - fire
 create_food_and_water:
   casting_time: 1 standard action
   components: V, S
@@ -2136,8 +2134,8 @@ daylight:
     - cleric
     - druid
     - evocation
-    - paladin
     - magus
+    - paladin
     - ranger
     - sorcerer
 death_ward:
@@ -2182,9 +2180,9 @@ delayed_blast_fireball:
     - PHB
   tags:
     - evocation
+    - fire
     - sorcerer
     - wizard
-    - fire
 demiplane:
   casting_time: 1 standard action
   components: S
@@ -2278,8 +2276,8 @@ detect_magic:
     - cleric
     - divination
     - druid
-    - paladin
     - magus
+    - paladin
     - ranger
     - ritual
     - sorcerer
@@ -2444,8 +2442,8 @@ dispel_magic:
     - bard
     - cleric
     - druid
-    - paladin
     - magus
+    - paladin
     - sorcerer
     - warlock
     - wizard
@@ -2528,8 +2526,7 @@ divine_smite:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
   concentration: false
-  description: |-
-    Your weapon shines with divine energy as you strike. The target takes 2d8 radiant damage, or 3d8 if it is a Fiend or Undead.
+  description: Your weapon shines with divine energy as you strike. The target takes 2d8 radiant damage, or 3d8 if it is a Fiend or Undead.
   duration: Instantaneous
   higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.
   level: 1
@@ -2776,12 +2773,12 @@ dust_devil:
     - EEPC
     - XGE
   tags:
+    - air
     - conjuration
     - druid
+    - earth
     - sorcerer
     - wizard
-    - air
-    - earth
 earth_tremor:
   casting_time: 1 standard action
   components: V, S
@@ -2798,11 +2795,11 @@ earth_tremor:
   tags:
     - bard
     - druid
+    - earth
     - evocation
     - magus
     - sorcerer
     - wizard
-    - earth
 earthbind:
   casting_time: 1 standard action
   components: V
@@ -2848,8 +2845,8 @@ earthen_grasp:
     - magus
     - sorcerer
     - transmutation
-    - wizard
     - water
+    - wizard
 earthquake:
   casting_time: 1 standard action
   components: V, S, M
@@ -2878,9 +2875,9 @@ earthquake:
   tags:
     - cleric
     - druid
+    - earth
     - evocation
     - sorcerer
-    - earth
 eldritch_blast:
   casting_time: 1 standard action
   components: V, S
@@ -2902,8 +2899,7 @@ eldritch_smite:
   casting_time: 1 free action, which you take when you hit with a weapon attack
   components: V
   concentration: false
-  description: |-
-    Your weapon hums with eldritch power, and the target takes 4d8 force damage. If it is Huge or smaller, you may also knock it prone.
+  description: Your weapon hums with eldritch power, and the target takes 4d8 force damage. If it is Huge or smaller, you may also knock it prone.
   duration: Instantaneous
   higher_level: If you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d8 for each slot level above 1st.
   level: 3
@@ -2913,8 +2909,8 @@ eldritch_smite:
     - 2D
   tags:
     - evocation
-    - warlock
     - smite
+    - warlock
 elemental_bane:
   casting_time: 1 standard action
   components: V, S
@@ -2929,16 +2925,16 @@ elemental_bane:
     - EEPC
     - XGE
   tags:
+    - air
     - artificer
     - druid
+    - earth
+    - fire
     - magus
     - transmutation
     - warlock
-    - wizard
-    - air
-    - earth
-    - fire
     - water
+    - wizard
 elemental_weapon:
   casting_time: 1 standard action
   components: V, S
@@ -2954,15 +2950,15 @@ elemental_weapon:
     - TCE
     - 2D
   tags:
+    - air
     - artificer
     - druid
-    - paladin
-    - magus
-    - ranger
-    - transmutation
-    - air
     - earth
     - fire
+    - magus
+    - paladin
+    - ranger
+    - transmutation
     - water
 enemies_abound:
   casting_time: 1 standard action
@@ -3142,17 +3138,17 @@ erupting_earth:
     - XGE
   tags:
     - druid
+    - earth
     - sorcerer
     - transmutation
     - wizard
-    - earth
 ethereal_strike:
   casting_time: 1 free action, which you take when you make a melee weapon attack
   components: V
   concentration: false
   description: |-
     You temporarily transform one weapon you're holding or an unarmed strike into pure psionic energy. Instead of rolling to attack, your weapon phases through their armor. The target instead must make a Dexterity saving throw or take the damage from the attack and an additional 2d8 force damage and suffer all other effects associated with being hit by the attack. If they succeed, they take half damage from the attack, and suffer no other effects from being hit by the attack.
-  
+
     When you deal damage with this spell, your weapon's damage is converted to force damage.
   duration: Instantaneous
   higher_level: If you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.
@@ -3163,8 +3159,8 @@ ethereal_strike:
     - 2D
   tags:
     - magus
-    - transmutation
     - smite
+    - transmutation
 etherealness:
   casting_time: 1 standard action
   components: V, S
@@ -3549,10 +3545,10 @@ fire_bolt:
   tags:
     - artificer
     - evocation
+    - fire
     - magus
     - sorcerer
     - wizard
-    - fire
 fire_shield:
   casting_time: 1 standard action
   components: V, S, M
@@ -3574,11 +3570,11 @@ fire_shield:
   tags:
     - druid
     - evocation
+    - fire
     - magus
     - sorcerer
-    - wizard
-    - fire
     - water
+    - wizard
 fire_storm:
   casting_time: 1 standard action
   components: V, S
@@ -3597,8 +3593,8 @@ fire_storm:
     - cleric
     - druid
     - evocation
-    - sorcerer
     - fire
+    - sorcerer
 fireball:
   casting_time: 1 standard action
   components: V, S, M
@@ -3617,9 +3613,9 @@ fireball:
     - PHB
   tags:
     - evocation
+    - fire
     - sorcerer
     - wizard
-    - fire
 flame_arrows:
   casting_time: 1 standard action
   components: V, S
@@ -3636,11 +3632,11 @@ flame_arrows:
   tags:
     - artificer
     - druid
+    - fire
     - ranger
     - sorcerer
     - transmutation
     - wizard
-    - fire
 flame_blade:
   casting_time: 1 minor action
   components: V, S, M
@@ -3663,9 +3659,9 @@ flame_blade:
   tags:
     - druid
     - evocation
+    - fire
     - magus
     - sorcerer
-    - fire
 flame_strike:
   casting_time: 1 standard action
   components: V, S, M
@@ -3705,9 +3701,9 @@ flaming_sphere:
   tags:
     - conjuration
     - druid
+    - fire
     - sorcerer
     - wizard
-    - fire
 flaming_stride:
   casting_time: 1 minor action
   components: V, S
@@ -3725,12 +3721,12 @@ flaming_stride:
     - FTD
   tags:
     - artificer
+    - fire
     - magus
     - ranger
     - sorcerer
     - transmutation
     - wizard
-    - fire
 floating_disk:
   casting_time: 1 standard action
   components: V, S, M
@@ -3785,14 +3781,14 @@ fog_cloud:
   sources:
     - PHB
   tags:
+    - air
     - conjuration
     - druid
     - magus
     - ranger
     - sorcerer
-    - wizard
-    - air
     - water
+    - wizard
 forbiddance:
   casting_time: 10 minutes
   components: V, S, M
@@ -3882,8 +3878,8 @@ freezing_sphere:
   tags:
     - evocation
     - sorcerer
-    - wizard
     - water
+    - wizard
 friends:
   casting_time: 1 standard action
   components: S, M
@@ -3906,8 +3902,7 @@ frost_strike:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
   concentration: false
-  description: |-
-    The air chills around your weapon. The target takes 1d6 cold damage, and you gain temporary hit points equal to the cold damage rolled for the duration of the spell.
+  description: The air chills around your weapon. The target takes 1d6 cold damage, and you gain temporary hit points equal to the cold damage rolled for the duration of the spell.
   duration: Up to 1 minute
   higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
   level: 1
@@ -3942,8 +3937,8 @@ frostbite:
     - magus
     - sorcerer
     - warlock
-    - wizard
     - water
+    - wizard
 gaseous_form:
   casting_time: 1 standard action
   components: V, S, M
@@ -4268,11 +4263,11 @@ green_flame_blade:
   tags:
     - artificer
     - evocation
+    - fire
     - magus
     - sorcerer
     - warlock
     - wizard
-    - fire
 grim_apparitions:
   casting_time: 1 minor action
   components: V, S
@@ -4413,11 +4408,11 @@ gust:
     - EEPC
     - XGE
   tags:
+    - air
     - druid
     - sorcerer
     - transmutation
     - wizard
-    - air
 gust_of_wind:
   casting_time: 1 standard action
   components: V, S, M
@@ -4439,12 +4434,12 @@ gust_of_wind:
     - PHB
     - TCE
   tags:
+    - air
     - druid
     - evocation
     - ranger
     - sorcerer
     - wizard
-    - air
 hail_of_thorns:
   casting_time: 1 free action, which you take when you hit with a ranged weapon attack
   components: V
@@ -4664,8 +4659,8 @@ heat_metal:
     - artificer
     - bard
     - druid
-    - transmutation
     - earth
+    - transmutation
 hellish_rebuke:
   casting_time: 1 reaction, which you take in response to being damaged by a creature within 60 feet of you that you can see
   components: V, S
@@ -4872,8 +4867,8 @@ ice_knife:
     - druid
     - magus
     - sorcerer
-    - wizard
     - water
+    - wizard
 ice_storm:
   casting_time: 1 standard action
   components: V, S, M
@@ -4894,8 +4889,8 @@ ice_storm:
     - druid
     - evocation
     - sorcerer
-    - wizard
     - water
+    - wizard
 identify:
   casting_time: 1 minute
   components: V, S, M
@@ -4961,10 +4956,10 @@ immolation:
     - 2D
   tags:
     - evocation
+    - fire
     - magus
     - sorcerer
     - wizard
-    - fire
 imprisonment:
   casting_time: 1 minute
   components: V, S, M
@@ -5028,12 +5023,12 @@ incendiary_cloud:
     - PHB
     - TCE
   tags:
+    - air
     - conjuration
     - druid
+    - fire
     - sorcerer
     - wizard
-    - air
-    - fire
 indestructible_sphere:
   casting_time: 1 standard action
   components: V, S, M
@@ -5155,11 +5150,11 @@ investiture_of_flame:
     - XGE
   tags:
     - druid
+    - fire
     - sorcerer
     - transmutation
     - warlock
     - wizard
-    - fire
 investiture_of_ice:
   casting_time: 1 standard action
   components: V, S
@@ -5183,8 +5178,8 @@ investiture_of_ice:
     - sorcerer
     - transmutation
     - warlock
-    - wizard
     - water
+    - wizard
 investiture_of_stone:
   casting_time: 1 standard action
   components: V, S
@@ -5204,11 +5199,11 @@ investiture_of_stone:
     - XGE
   tags:
     - druid
+    - earth
     - sorcerer
     - transmutation
     - warlock
     - wizard
-    - earth
 investiture_of_wind:
   casting_time: 1 standard action
   components: V, S
@@ -5227,12 +5222,12 @@ investiture_of_wind:
     - EEPC
     - XGE
   tags:
+    - air
     - druid
     - sorcerer
     - transmutation
     - warlock
     - wizard
-    - air
 invisibility:
   casting_time: 1 standard action
   components: V, S, M
@@ -5451,11 +5446,11 @@ lightning_arrow:
     - PHB
     - 2D
   tags:
-    - ranger
-    - transmutation
-    - smite
     - air
     - fire
+    - ranger
+    - smite
+    - transmutation
 lightning_bolt:
   casting_time: 1 standard action
   components: V, S, M
@@ -5473,12 +5468,12 @@ lightning_bolt:
   sources:
     - PHB
   tags:
+    - air
     - evocation
+    - fire
     - magus
     - sorcerer
     - wizard
-    - air
-    - fire
 lightning_lure:
   casting_time: 1 standard action
   components: V
@@ -5494,14 +5489,14 @@ lightning_lure:
   sources:
     - TCE
   tags:
+    - air
     - artificer
     - evocation
+    - fire
     - magus
     - sorcerer
     - warlock
     - wizard
-    - air
-    - fire
 locate:
   casting_time: 1 standard action
   components: V, S, M
@@ -5802,10 +5797,10 @@ mantle_of_meteors:
     - EEPC
     - XGE
   tags:
+    - fire
     - sorcerer
     - transmutation
     - wizard
-    - fire
 mass_cure_wounds:
   casting_time: 1 standard action
   components: V, S
@@ -6285,10 +6280,10 @@ mold_earth:
     - XGE
   tags:
     - druid
+    - earth
     - sorcerer
     - transmutation
     - wizard
-    - earth
 moonbeam:
   casting_time: 1 standard action
   components: V, S, M
@@ -6335,10 +6330,10 @@ move_earth:
     - PHB
   tags:
     - druid
+    - earth
     - sorcerer
     - transmutation
     - wizard
-    - earth
 negative_energy_flood:
   casting_time: 1 standard action
   components: V, M
@@ -6840,8 +6835,8 @@ primordial_ward:
     - XGE
   tags:
     - abjuration
-    - druid
     - air
+    - druid
     - earth
     - fire
     - water
@@ -6958,17 +6953,17 @@ protection_from_energy:
     - PHB
   tags:
     - abjuration
+    - air
     - artificer
     - cleric
     - druid
+    - earth
+    - fire
     - magus
     - ranger
     - sorcerer
-    - wizard
-    - air
-    - earth
-    - fire
     - water
+    - wizard
 protection_from_evil_and_good:
   casting_time: 1 standard action
   components: V, S, M
@@ -7093,10 +7088,10 @@ pyrotechnics:
   tags:
     - artificer
     - bard
+    - fire
     - sorcerer
     - transmutation
     - wizard
-    - fire
 quaking_blow:
   casting_time: 1 standard action
   components: S, M
@@ -7114,11 +7109,11 @@ quaking_blow:
     - 2D
   tags:
     - artificer
+    - earth
     - evocation
     - magus
     - sorcerer
     - warlock
-    - earth
 raise_dead:
   casting_time: 1 hour
   components: V, S, M
@@ -7177,8 +7172,8 @@ ray_of_frost:
     - evocation
     - magus
     - sorcerer
-    - wizard
     - water
+    - wizard
 ray_of_sickness:
   casting_time: 1 standard action
   components: V, S
@@ -7466,8 +7461,7 @@ sapping_strike:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
   concentration: false
-  description: |-
-    You wreath your weapon in necrotic energy. The target takes 1d6 necrotic damage and must then make a Constitution saving throw. On a failure, the target is slowed until the end of your next turn. Constructs and Undead are immune to the slowed condition inflicted by this spell.
+  description: You wreath your weapon in necrotic energy. The target takes 1d6 necrotic damage and must then make a Constitution saving throw. On a failure, the target is slowed until the end of your next turn. Constructs and Undead are immune to the slowed condition inflicted by this spell.
   duration: Up to 1 round
   higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
   level: 1
@@ -7511,10 +7505,10 @@ scorching_blast:
     - XGE
   tags:
     - evocation
+    - fire
     - magus
     - sorcerer
     - wizard
-    - fire
 scorching_ray:
   casting_time: 1 standard action
   components: V, S
@@ -7532,10 +7526,10 @@ scorching_ray:
     - PHB
   tags:
     - evocation
+    - fire
     - magus
     - sorcerer
     - wizard
-    - fire
 scrying:
   casting_time: 10 minutes
   components: V, S, M
@@ -7589,11 +7583,11 @@ searing_smite:
     - 2D
   tags:
     - evocation
+    - fire
     - magus
     - paladin
     - ranger
     - smite
-    - fire
 secret_chest:
   casting_time: 1 standard action
   components: V, S, M
@@ -7724,8 +7718,8 @@ shape_water:
     - druid
     - sorcerer
     - transmutation
-    - wizard
     - water
+    - wizard
 shapechange:
   casting_time: 1 standard action
   components: V, S, M
@@ -7836,13 +7830,13 @@ shocking_grasp:
   sources:
     - PHB
   tags:
+    - air
     - artificer
     - evocation
+    - fire
     - magus
     - sorcerer
     - wizard
-    - air
-    - fire
 sickening_radiance:
   casting_time: 1 standard action
   components: V, S
@@ -7991,8 +7985,8 @@ sleet_storm:
     - conjuration
     - druid
     - sorcerer
-    - wizard
     - water
+    - wizard
 slow:
   casting_time: 1 standard action
   components: V, S, M
@@ -8035,8 +8029,8 @@ snow_flurry:
   tags:
     - evocation
     - sorcerer
-    - wizard
     - water
+    - wizard
 soul_cage:
   casting_time: 1 reaction, which you take when a humanoid you can see within 60 feet of you dies
   components: V, S, M
@@ -8235,8 +8229,8 @@ staggering_smite:
     - 2D
   tags:
     - evocation
-    - paladin
     - magus
+    - paladin
     - smite
 steel_wind_strike:
   casting_time: 1 standard action
@@ -8345,9 +8339,9 @@ storm_of_vengeance:
   sources:
     - PHB
   tags:
+    - air
     - conjuration
     - druid
-    - air
     - fire
     - water
 storm_sphere:
@@ -8369,11 +8363,11 @@ storm_sphere:
     - EEPC
     - XGE
   tags:
+    - air
     - evocation
+    - fire
     - sorcerer
     - wizard
-    - air
-    - fire
 suggestion:
   casting_time: 1 standard action
   components: V, M
@@ -9037,6 +9031,7 @@ thunderclap:
     - EEPC
     - XGE
   tags:
+    - air
     - artificer
     - bard
     - druid
@@ -9045,7 +9040,6 @@ thunderclap:
     - sorcerer
     - warlock
     - wizard
-    - air
 thunderous_smite:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
@@ -9059,11 +9053,11 @@ thunderous_smite:
     - PHB
     - 2D
   tags:
-    - evocation
-    - paladin
-    - magus
-    - smite
     - air
+    - evocation
+    - magus
+    - paladin
+    - smite
 thunderwave:
   casting_time: 1 standard action
   components: V, S
@@ -9080,13 +9074,13 @@ thunderwave:
   sources:
     - PHB
   tags:
+    - air
     - bard
     - druid
     - evocation
     - magus
     - sorcerer
     - wizard
-    - air
 tidal_wave:
   casting_time: 1 standard action
   components: V, S, M
@@ -9104,8 +9098,8 @@ tidal_wave:
     - conjuration
     - druid
     - sorcerer
-    - wizard
     - water
+    - wizard
 time_stop:
   casting_time: 1 standard action
   components: V
@@ -9207,10 +9201,10 @@ transmute_rock:
   tags:
     - artificer
     - druid
-    - transmutation
-    - wizard
     - earth
+    - transmutation
     - water
+    - wizard
 transport_via_plants:
   casting_time: 1 standard action
   components: V, S
@@ -9445,9 +9439,9 @@ wall_of_fire:
   tags:
     - druid
     - evocation
+    - fire
     - sorcerer
     - wizard
-    - fire
 wall_of_force:
   casting_time: 1 standard action
   components: V, S, M
@@ -9489,8 +9483,8 @@ wall_of_ice:
     - PHB
   tags:
     - evocation
-    - wizard
     - water
+    - wizard
 wall_of_light:
   casting_time: 1 standard action
   components: V, S, M
@@ -9530,9 +9524,9 @@ wall_of_sand:
     - EEPC
     - XGE
   tags:
+    - earth
     - evocation
     - wizard
-    - earth
 wall_of_stone:
   casting_time: 1 standard action
   components: V, S, M
@@ -9559,10 +9553,10 @@ wall_of_stone:
   tags:
     - artificer
     - druid
+    - earth
     - evocation
     - sorcerer
     - wizard
-    - earth
 wall_of_thorns:
   casting_time: 1 standard action
   components: V, S, M
@@ -9604,8 +9598,8 @@ wall_of_water:
     - druid
     - evocation
     - sorcerer
-    - wizard
     - water
+    - wizard
 warding_bond:
   casting_time: 1 standard action
   components: V, S, M
@@ -9647,13 +9641,13 @@ warding_wind:
     - EEPC
     - XGE
   tags:
+    - air
     - bard
     - druid
     - evocation
     - magus
     - sorcerer
     - wizard
-    - air
 water_breathing:
   casting_time: 1 standard action
   components: V, S, M
@@ -9722,8 +9716,8 @@ watery_sphere:
     - conjuration
     - druid
     - sorcerer
-    - wizard
     - water
+    - wizard
 web:
   casting_time: 1 standard action
   components: V, S, M
@@ -9787,11 +9781,11 @@ whirlwind:
     - EEPC
     - XGE
   tags:
+    - air
     - druid
     - evocation
     - sorcerer
     - wizard
-    - air
 wind_walk:
   casting_time: 1 minute
   components: V, S, M
@@ -9828,10 +9822,10 @@ wind_wall:
   sources:
     - PHB
   tags:
+    - air
     - druid
     - evocation
     - ranger
-    - air
 witch_bolt:
   casting_time: 1 standard action
   components: V, S, M
@@ -9847,12 +9841,12 @@ witch_bolt:
     - PHB
     - 2D
   tags:
+    - air
     - evocation
+    - fire
     - sorcerer
     - warlock
     - wizard
-    - air
-    - fire
 word_of_radiance:
   casting_time: 1 standard action
   components: V, M
@@ -9944,11 +9938,11 @@ zapping_strike:
   sources:
     - 2D
   tags:
+    - air
     - conjuration
+    - fire
     - magus
     - smite
-    - air
-    - fire
 zephyr_strike:
   casting_time: 1 minor action
   components: V
@@ -9964,7 +9958,7 @@ zephyr_strike:
   sources:
     - XGE
   tags:
+    - air
     - magus
     - ranger
     - transmutation
-    - air

--- a/spells.yml
+++ b/spells.yml
@@ -15,9 +15,14 @@ absorb_elements:
     - abjuration
     - artificer
     - druid
+    - magus
     - ranger
     - sorcerer
     - wizard
+    - air
+    - earth
+    - fire
+    - water
 acid_arrow:
   casting_time: 1 standard action
   components: V, S, M
@@ -51,6 +56,7 @@ acid_splash:
   tags:
     - artificer
     - conjuration
+    - magus
     - sorcerer
     - wizard
 aid:
@@ -72,6 +78,7 @@ aid:
     - bard
     - cleric
     - paladin
+    - magus
     - ranger
 alarm:
   casting_time: 1 minute
@@ -116,8 +123,9 @@ alter_self:
     - PHB
   tags:
     - artificer
-    - sorcerer
     - transmutation
+    - magus
+    - sorcerer
     - wizard
 animal_friendship:
   casting_time: 1 standard action
@@ -198,6 +206,7 @@ antilife_shell:
   tags:
     - abjuration
     - druid
+    - water
 antimagic_field:
   casting_time: 1 standard action
   components: V, S, M
@@ -322,6 +331,28 @@ arcane_lock:
     - abjuration
     - artificer
     - wizard
+arcane_weapon:
+  casting_time: 1 minor action
+  components: V, S, M
+  concentration: true
+  description: |-
+    You channel arcane energy into one weapon you're holding, and choose one damage type: acid, cold, fire, lightning, poison, or thunder. Until the spell ends, you deal an extra 1d4 damage of the chosen type to any target you hit with the weapon.
+  duration: up to 1 hour
+  higher_level: When you cast this spell using a spell slot of 3rd level or higher, you can maintain your concentration on the spell for up to 8 hours.
+  level: 1
+  material: a weapon
+  name: Arcane Weapon
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - transmutation
+    - artificer
+    - magus
+    - air
+    - earth
+    - fire
+    - water
 armor_of_ice:
   casting_time: 1 standard action
   components: V, S, M
@@ -337,7 +368,9 @@ armor_of_ice:
     - PHB
   tags:
     - abjuration
+    - magus
     - warlock
+    - water
 astral_projection:
   casting_time: 1 hour
   components: V, S, M
@@ -517,6 +550,7 @@ banishing_smite:
   tags:
     - abjuration
     - paladin
+    - magus
     - smite
 banishment:
   casting_time: 1 standard action
@@ -540,6 +574,7 @@ banishment:
     - abjuration
     - cleric
     - paladin
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -647,8 +682,10 @@ binding_ice:
     - FTD
   tags:
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - water
 blade_barrier:
   casting_time: 1 standard action
   components: V, S
@@ -701,9 +738,28 @@ blade_ward:
   tags:
     - abjuration
     - bard
+    - magus
     - sorcerer
     - warlock
     - wizard
+blazing_strike:
+  casting_time: 1 free action, which you take when you hit with a melee weapon attack
+  components: V
+  concentration: false
+  description: |-
+    Fire erupts from your weapon. The target, as well as each other creature of your choice within 10 feet of it, takes 1d6 fire damage.
+  duration: Instantaneous
+  higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
+  level: 1
+  name: Blazing Strike
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - evocation
+    - magus
+    - smite
+    - fire
 bless:
   casting_time: 1 standard action
   components: V, S, M
@@ -796,6 +852,7 @@ blink:
     - artificer
     - sorcerer
     - transmutation
+    - magus
     - wizard
 blur:
   casting_time: 1 standard action
@@ -812,6 +869,7 @@ blur:
     - artificer
     - illusion
     - sorcerer
+    - magus
     - wizard
 bones_of_the_earth:
   casting_time: 1 standard action
@@ -834,6 +892,7 @@ bones_of_the_earth:
   tags:
     - druid
     - transmutation
+    - earth
 booming_blade:
   casting_time: 1 standard action
   components: S, M
@@ -852,9 +911,11 @@ booming_blade:
   tags:
     - artificer
     - evocation
+    - magus
     - sorcerer
     - warlock
     - wizard
+    - air
 branding_smite:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
@@ -889,8 +950,10 @@ burning_hands:
     - PHB
   tags:
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - fire
 call_lightning:
   casting_time: 1 standard action
   components: V, S
@@ -910,6 +973,8 @@ call_lightning:
   tags:
     - conjuration
     - druid
+    - air
+    - fire
 calm_emotions:
   casting_time: 1 standard action
   components: V, S
@@ -943,6 +1008,7 @@ catapult:
     - XGE
   tags:
     - artificer
+    - magus
     - sorcerer
     - transmutation
     - wizard
@@ -997,6 +1063,7 @@ caustic_spray:
   tags:
     - artificer
     - evocation
+    - magus
     - sorcerer
     - wizard
 chain_lightning:
@@ -1019,6 +1086,8 @@ chain_lightning:
     - evocation
     - sorcerer
     - wizard
+    - air
+    - fire
 chaos_bolt:
   casting_time: 1 standard action
   components: V, S
@@ -1124,8 +1193,13 @@ chromatic_orb:
     - PHB
   tags:
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - air
+    - earth
+    - fire
+    - water
 circle_of_death:
   casting_time: 1 standard action
   components: V, S, M
@@ -1198,6 +1272,7 @@ cloak_of_shadow:
     - XGE
   tags:
     - necromancy
+    - magus
     - warlock
 clone:
   casting_time: 1 hour
@@ -1233,6 +1308,7 @@ cloud_of_daggers:
   tags:
     - bard
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -1277,6 +1353,7 @@ color_spray:
   tags:
     - bard
     - illusion
+    - magus
     - sorcerer
     - wizard
 command:
@@ -1434,8 +1511,10 @@ cone_of_cold:
   tags:
     - druid
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - air
 confusion:
   casting_time: 1 standard action
   components: V, S, M
@@ -1612,6 +1691,7 @@ control_flames:
     - sorcerer
     - transmutation
     - wizard
+    - fire
 control_water:
   casting_time: 1 standard action
   components: V, S, M
@@ -1640,6 +1720,7 @@ control_water:
     - druid
     - transmutation
     - wizard
+    - water
 control_weather:
   casting_time: 10 minutes
   components: V, S, M
@@ -1690,6 +1771,8 @@ control_weather:
     - druid
     - transmutation
     - wizard
+    - air
+    - water
 control_winds:
   casting_time: 1 standard action
   components: V, S
@@ -1714,6 +1797,7 @@ control_winds:
     - sorcerer
     - transmutation
     - wizard
+    - air
 cordon_of_arrows:
   casting_time: 1 standard action
   components: V, S, M
@@ -1771,9 +1855,11 @@ create_bonfire:
     - artificer
     - conjuration
     - druid
+    - magus
     - sorcerer
     - warlock
     - wizard
+    - fire
 create_food_and_water:
   casting_time: 1 standard action
   components: V, S
@@ -1812,6 +1898,7 @@ create_or_destroy_water:
     - cleric
     - druid
     - transmutation
+    - water
 creation:
   casting_time: 1 minute
   components: V, S, M
@@ -1841,6 +1928,7 @@ creation:
   tags:
     - artificer
     - illusion
+    - magus
     - sorcerer
     - wizard
 crown_of_madness:
@@ -1940,6 +2028,7 @@ dancing_lights:
     - artificer
     - bard
     - evocation
+    - magus
     - sorcerer
     - wizard
 danse_macabre:
@@ -1982,6 +2071,7 @@ darkness:
     - PHB
   tags:
     - evocation
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -2000,6 +2090,7 @@ darkvision:
   tags:
     - artificer
     - druid
+    - magus
     - ranger
     - sorcerer
     - transmutation
@@ -2046,6 +2137,7 @@ daylight:
     - druid
     - evocation
     - paladin
+    - magus
     - ranger
     - sorcerer
 death_ward:
@@ -2092,6 +2184,7 @@ delayed_blast_fireball:
     - evocation
     - sorcerer
     - wizard
+    - fire
 demiplane:
   casting_time: 1 standard action
   components: S
@@ -2186,6 +2279,7 @@ detect_magic:
     - divination
     - druid
     - paladin
+    - magus
     - ranger
     - ritual
     - sorcerer
@@ -2236,6 +2330,7 @@ detect_thoughts:
   tags:
     - bard
     - divination
+    - magus
     - sorcerer
     - wizard
 dimension_door:
@@ -2257,6 +2352,7 @@ dimension_door:
   tags:
     - bard
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -2280,6 +2376,7 @@ disguise_self:
     - artificer
     - bard
     - illusion
+    - magus
     - sorcerer
     - wizard
 disintegrate:
@@ -2348,6 +2445,7 @@ dispel_magic:
     - cleric
     - druid
     - paladin
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -2665,6 +2763,8 @@ dust_devil:
     - druid
     - sorcerer
     - wizard
+    - air
+    - earth
 earth_tremor:
   casting_time: 1 standard action
   components: V, S
@@ -2682,8 +2782,10 @@ earth_tremor:
     - bard
     - druid
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - earth
 earthbind:
   casting_time: 1 standard action
   components: V
@@ -2700,6 +2802,7 @@ earthbind:
     - 2D
   tags:
     - druid
+    - magus
     - sorcerer
     - transmutation
     - warlock
@@ -2725,9 +2828,11 @@ earthen_grasp:
     - EEPC
     - XGE
   tags:
+    - magus
     - sorcerer
     - transmutation
     - wizard
+    - water
 earthquake:
   casting_time: 1 standard action
   components: V, S, M
@@ -2758,6 +2863,7 @@ earthquake:
     - druid
     - evocation
     - sorcerer
+    - earth
 eldritch_blast:
   casting_time: 1 standard action
   components: V, S
@@ -2791,9 +2897,14 @@ elemental_bane:
   tags:
     - artificer
     - druid
+    - magus
     - transmutation
     - warlock
     - wizard
+    - air
+    - earth
+    - fire
+    - water
 elemental_weapon:
   casting_time: 1 standard action
   components: V, S
@@ -2812,8 +2923,13 @@ elemental_weapon:
     - artificer
     - druid
     - paladin
+    - magus
     - ranger
     - transmutation
+    - air
+    - earth
+    - fire
+    - water
 enemies_abound:
   casting_time: 1 standard action
   components: V, S
@@ -2887,6 +3003,7 @@ enhance_ability:
     - bard
     - cleric
     - druid
+    - magus
     - ranger
     - sorcerer
     - transmutation
@@ -2915,6 +3032,7 @@ enlarge_reduce:
     - artificer
     - bard
     - druid
+    - magus
     - sorcerer
     - transmutation
     - wizard
@@ -2993,6 +3111,26 @@ erupting_earth:
     - sorcerer
     - transmutation
     - wizard
+    - earth
+ethereal_strike:
+  casting_time: 1 free action, which you take when you make a melee weapon attack
+  components: V
+  concentration: false
+  description: |-
+    You temporarily transform one weapon you're holding or an unarmed strike into pure psionic energy. Instead of rolling to attack, your weapon phases through their armor. The target instead must make a Dexterity saving throw or take the damage from the attack and an additional 2d8 force damage and suffer all other effects associated with being hit by the attack. If they succeed, they take half damage from the attack, and suffer no other effects from being hit by the attack.
+  
+    When you deal damage with this spell, your weapon's damage is converted to force damage.
+  duration: Instantaneous
+  higher_level: If you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.
+  level: 2
+  name: Ethereal Strike
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - magus
+    - transmutation
+    - smite
 etherealness:
   casting_time: 1 standard action
   components: V, S
@@ -3061,6 +3199,7 @@ expeditious_retreat:
     - PHB
   tags:
     - artificer
+    - magus
     - sorcerer
     - transmutation
     - warlock
@@ -3104,6 +3243,7 @@ faerie_fire:
     - bard
     - druid
     - evocation
+    - magus
 false_life:
   casting_time: 1 standard action
   components: V, S, M
@@ -3119,6 +3259,7 @@ false_life:
     - PHB
   tags:
     - artificer
+    - magus
     - necromancy
     - sorcerer
     - wizard
@@ -3154,6 +3295,7 @@ far_step:
     - 2D
   tags:
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -3175,6 +3317,7 @@ fear:
   tags:
     - bard
     - illusion
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -3193,6 +3336,7 @@ feather_fall:
   tags:
     - artificer
     - bard
+    - magus
     - sorcerer
     - transmutation
     - wizard
@@ -3371,8 +3515,10 @@ fire_bolt:
   tags:
     - artificer
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - fire
 fire_shield:
   casting_time: 1 standard action
   components: V, S, M
@@ -3394,8 +3540,11 @@ fire_shield:
   tags:
     - druid
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - fire
+    - water
 fire_storm:
   casting_time: 1 standard action
   components: V, S
@@ -3415,6 +3564,7 @@ fire_storm:
     - druid
     - evocation
     - sorcerer
+    - fire
 fireball:
   casting_time: 1 standard action
   components: V, S, M
@@ -3435,6 +3585,7 @@ fireball:
     - evocation
     - sorcerer
     - wizard
+    - fire
 flame_arrows:
   casting_time: 1 standard action
   components: V, S
@@ -3455,6 +3606,7 @@ flame_arrows:
     - sorcerer
     - transmutation
     - wizard
+    - fire
 flame_blade:
   casting_time: 1 minor action
   components: V, S, M
@@ -3477,7 +3629,9 @@ flame_blade:
   tags:
     - druid
     - evocation
+    - magus
     - sorcerer
+    - fire
 flame_strike:
   casting_time: 1 standard action
   components: V, S, M
@@ -3519,6 +3673,7 @@ flaming_sphere:
     - druid
     - sorcerer
     - wizard
+    - fire
 flaming_stride:
   casting_time: 1 minor action
   components: V, S
@@ -3536,10 +3691,12 @@ flaming_stride:
     - FTD
   tags:
     - artificer
+    - magus
     - ranger
     - sorcerer
     - transmutation
     - wizard
+    - fire
 floating_disk:
   casting_time: 1 standard action
   components: V, S, M
@@ -3576,6 +3733,7 @@ fly:
     - PHB
   tags:
     - artificer
+    - magus
     - sorcerer
     - transmutation
     - warlock
@@ -3595,9 +3753,12 @@ fog_cloud:
   tags:
     - conjuration
     - druid
+    - magus
     - ranger
     - sorcerer
     - wizard
+    - air
+    - water
 forbiddance:
   casting_time: 10 minutes
   components: V, S, M
@@ -3663,6 +3824,7 @@ freedom_of_movement:
     - bard
     - cleric
     - druid
+    - magus
     - ranger
 freezing_sphere:
   casting_time: 1 standard action
@@ -3687,6 +3849,7 @@ freezing_sphere:
     - evocation
     - sorcerer
     - wizard
+    - water
 friends:
   casting_time: 1 standard action
   components: S, M
@@ -3705,6 +3868,24 @@ friends:
     - sorcerer
     - warlock
     - wizard
+frost_strike:
+  casting_time: 1 free action, which you take when you hit with a melee weapon attack
+  components: V
+  concentration: false
+  description: |-
+    The air chills around your weapon. The target takes 1d6 cold damage, and you gain temporary hit points equal to the cold damage rolled for the duration of the spell.
+  duration: up to 1 minute
+  higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
+  level: 1
+  name: Frost Strike
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - abjuration
+    - magus
+    - smite
+    - water
 frostbite:
   casting_time: 1 standard action
   components: V, S
@@ -3724,9 +3905,11 @@ frostbite:
     - artificer
     - druid
     - evocation
+    - magus
     - sorcerer
     - warlock
     - wizard
+    - water
 gaseous_form:
   casting_time: 1 standard action
   components: V, S, M
@@ -3987,6 +4170,7 @@ grease:
   tags:
     - artificer
     - conjuration
+    - magus
     - sorcerer
     - wizard
 greater_invisibility:
@@ -4003,6 +4187,7 @@ greater_invisibility:
   tags:
     - bard
     - illusion
+    - magus
     - sorcerer
     - wizard
 greater_restoration:
@@ -4049,7 +4234,31 @@ green_flame_blade:
   tags:
     - artificer
     - evocation
+    - magus
     - sorcerer
+    - warlock
+    - wizard
+    - fire
+grim_apparitions:
+  casting_time: 1 minor action
+  components: V, S
+  concentration: true
+  description: |-
+    You call forth spirits of the dead, which flit around you to a distance of 10 feet for the spell's duration. The spirits are intangible and invulnerable.
+
+    When you cast this spell, you can designate any number of creatures you can see to be unaffected by it. An affected creature can't regain hit points while in the area, and when the creature enters the area for the first time on a turn or starts its turn there, it must make a Wisdom saving throw. On a failed save, it loses all of its temporary hit points.
+  duration: Up to 1 minute
+  level: 3
+  name: Spirit Shroud
+  range: Self
+  sources:
+    - TCE
+    - 2D
+  tags:
+    - cleric
+    - magus
+    - necromancy
+    - paladin
     - warlock
     - wizard
 guardian_of_nature:
@@ -4174,6 +4383,7 @@ gust:
     - sorcerer
     - transmutation
     - wizard
+    - air
 gust_of_wind:
   casting_time: 1 standard action
   components: V, S, M
@@ -4200,6 +4410,7 @@ gust_of_wind:
     - ranger
     - sorcerer
     - wizard
+    - air
 hail_of_thorns:
   casting_time: 1 free action, which you take when you hit with a ranged weapon attack
   components: V
@@ -4341,6 +4552,7 @@ haste:
     - PHB
   tags:
     - artificer
+    - magus
     - sorcerer
     - transmutation
     - wizard
@@ -4419,6 +4631,7 @@ heat_metal:
     - bard
     - druid
     - transmutation
+    - earth
 hellish_rebuke:
   casting_time: 1 reaction, which you take in response to being damaged by a creature within 60 feet of you that you can see
   components: V, S
@@ -4623,8 +4836,10 @@ ice_knife:
   tags:
     - conjuration
     - druid
+    - magus
     - sorcerer
     - wizard
+    - water
 ice_storm:
   casting_time: 1 standard action
   components: V, S, M
@@ -4646,6 +4861,7 @@ ice_storm:
     - evocation
     - sorcerer
     - wizard
+    - water
 identify:
   casting_time: 1 minute
   components: V, S, M
@@ -4711,8 +4927,10 @@ immolation:
     - 2D
   tags:
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - fire
 imprisonment:
   casting_time: 1 minute
   components: V, S, M
@@ -4780,6 +4998,8 @@ incendiary_cloud:
     - druid
     - sorcerer
     - wizard
+    - air
+    - fire
 indestructible_sphere:
   casting_time: 1 standard action
   components: V, S, M
@@ -4838,6 +5058,7 @@ inflict_wounds:
     - PHB
   tags:
     - cleric
+    - magus
     - necromancy
 insect_plague:
   casting_time: 1 standard action
@@ -4904,6 +5125,7 @@ investiture_of_flame:
     - transmutation
     - warlock
     - wizard
+    - fire
 investiture_of_ice:
   casting_time: 1 standard action
   components: V, S
@@ -4928,6 +5150,7 @@ investiture_of_ice:
     - transmutation
     - warlock
     - wizard
+    - water
 investiture_of_stone:
   casting_time: 1 standard action
   components: V, S
@@ -4951,6 +5174,7 @@ investiture_of_stone:
     - transmutation
     - warlock
     - wizard
+    - earth
 investiture_of_wind:
   casting_time: 1 standard action
   components: V, S
@@ -4974,6 +5198,7 @@ investiture_of_wind:
     - transmutation
     - warlock
     - wizard
+    - air
 invisibility:
   casting_time: 1 standard action
   components: V, S, M
@@ -4991,6 +5216,7 @@ invisibility:
     - artificer
     - bard
     - illusion
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -5043,6 +5269,7 @@ jump:
   tags:
     - artificer
     - druid
+    - magus
     - ranger
     - sorcerer
     - transmutation
@@ -5128,6 +5355,7 @@ levitate:
     - PHB
   tags:
     - artificer
+    - magus
     - sorcerer
     - transmutation
     - wizard
@@ -5167,6 +5395,7 @@ light:
     - bard
     - cleric
     - evocation
+    - magus
     - sorcerer
     - wizard
 lightning_arrow:
@@ -5191,6 +5420,8 @@ lightning_arrow:
     - ranger
     - transmutation
     - smite
+    - air
+    - fire
 lightning_bolt:
   casting_time: 1 standard action
   components: V, S, M
@@ -5209,8 +5440,11 @@ lightning_bolt:
     - PHB
   tags:
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - air
+    - fire
 lightning_lure:
   casting_time: 1 standard action
   components: V
@@ -5228,9 +5462,12 @@ lightning_lure:
   tags:
     - artificer
     - evocation
+    - magus
     - sorcerer
     - warlock
     - wizard
+    - air
+    - fire
 locate:
   casting_time: 1 standard action
   components: V, S, M
@@ -5274,6 +5511,7 @@ longstrider:
     - artificer
     - bard
     - druid
+    - magus
     - ranger
     - transmutation
     - wizard
@@ -5312,6 +5550,7 @@ maelstrom:
   tags:
     - druid
     - evocation
+    - water
 mage_armor:
   casting_time: 1 standard action
   components: V, S, M
@@ -5326,6 +5565,7 @@ mage_armor:
     - PHB
   tags:
     - abjuration
+    - magus
     - sorcerer
     - wizard
 mage_hand:
@@ -5348,6 +5588,7 @@ mage_hand:
     - artificer
     - bard
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -5481,6 +5722,7 @@ magic_weapon:
     - TCE
   tags:
     - artificer
+    - magus
     - paladin
     - ranger
     - sorcerer
@@ -5507,6 +5749,7 @@ major_image:
   tags:
     - bard
     - illusion
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -5528,6 +5771,7 @@ mantle_of_meteors:
     - sorcerer
     - transmutation
     - wizard
+    - fire
 mass_cure_wounds:
   casting_time: 1 standard action
   components: V, S
@@ -5838,6 +6082,7 @@ minor_illusion:
   tags:
     - bard
     - illusion
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -5888,6 +6133,7 @@ mirror_image:
   tags:
     - bard
     - illusion
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -5955,6 +6201,7 @@ misty_step:
     - PHB
   tags:
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -6007,6 +6254,7 @@ mold_earth:
     - sorcerer
     - transmutation
     - wizard
+    - earth
 moonbeam:
   casting_time: 1 standard action
   components: V, S, M
@@ -6056,6 +6304,7 @@ move_earth:
     - sorcerer
     - transmutation
     - wizard
+    - earth
 negative_energy_flood:
   casting_time: 1 standard action
   components: V, M
@@ -6090,6 +6339,7 @@ nondetection:
   tags:
     - abjuration
     - bard
+    - magus
     - ranger
     - wizard
 otherworldly_guise:
@@ -6382,6 +6632,7 @@ poison_spray:
   tags:
     - artificer
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -6516,6 +6767,7 @@ prestidigitation:
   tags:
     - artificer
     - bard
+    - prestidigitation
     - sorcerer
     - transmutation
     - warlock
@@ -6555,6 +6807,10 @@ primordial_ward:
   tags:
     - abjuration
     - druid
+    - air
+    - earth
+    - fire
+    - water
 prismatic_spray:
   casting_time: 1 standard action
   components: V, S
@@ -6608,6 +6864,7 @@ produce_flame:
   tags:
     - conjuration
     - druid
+    - fire
 programmed_illusion:
   casting_time: 1 standard action
   components: V, S, M
@@ -6670,9 +6927,14 @@ protection_from_energy:
     - artificer
     - cleric
     - druid
+    - magus
     - ranger
     - sorcerer
     - wizard
+    - air
+    - earth
+    - fire
+    - water
 protection_from_evil_and_good:
   casting_time: 1 standard action
   components: V, S, M
@@ -6800,6 +7062,29 @@ pyrotechnics:
     - sorcerer
     - transmutation
     - wizard
+    - fire
+quaking_blow:
+  casting_time: 1 standard action
+  components: S, M
+  concentration: false
+  description: |-
+    You brandish the weapon used in the spell's casting and make a melee attack with it against one creature within reach. On a hit, the target suffers the weapon attack's normal effects and the ground beneath them shakes. The ground within 5 feet of the target becomes difficult terrain for 1 minute.
+
+    This spell's damage increases when you reach certain levels. At 5th level, the melee attack deals an extra 1d8 bludgeoning damage to the target on a hit. The damage increases by 1d8 at 11th level (2d8) and again at 17th level (3d8).
+  duration: Instantaneous
+  level: 0
+  material: a weapon
+  name: Quaking Blow
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - artificer
+    - evocation
+    - magus
+    - sorcerer
+    - warlock
+    - earth
 raise_dead:
   casting_time: 1 hour
   components: V, S, M
@@ -6856,8 +7141,10 @@ ray_of_frost:
   tags:
     - artificer
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - water
 ray_of_sickness:
   casting_time: 1 standard action
   components: V, S
@@ -7031,6 +7318,28 @@ revivify:
     - necromancy
     - paladin
     - ranger
+rime_blade:
+  casting_time: 1 standard action
+  components: S, M
+  concentration: false
+  description: |-
+    You brandish the weapon used in the spell's casting and make a melee attack with it against one creature within reach. On a hit, the target suffers the weapon attack's normal effects and then becomes chilled by the icy blow. The creature's movement speed is reduced by 10 feet until the end of your next turn. This chill can spread to one creature of your choice within 5 feet of the target, also reducing their movement speed in the same way.
+
+    This spell's damage increases when you reach certain levels. At 5th level, the melee attack deals an extra 1d8 cold damage to the target on a hit. The damage increases by 1d8 at 11th level (2d8) and again at 17th level (3d8).
+  duration: up to 1 round
+  level: 0
+  material: a weapon
+  name: Rime Blade
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - artificer
+    - evocation
+    - magus
+    - sorcerer
+    - warlock
+    - water
 rope_trick:
   casting_time: 1 standard action
   components: V, S, M
@@ -7119,6 +7428,23 @@ sanctum:
     - abjuration
     - artificer
     - wizard
+sapping_strike:
+  casting_time: 1 free action, which you take when you hit with a melee weapon attack
+  components: V
+  concentration: false
+  description: |-
+    You wreath your weapon in necrotic energy. The target takes 1d6 necrotic damage and must then make a Constitution saving throw. On a failure, the target is slowed until the end of your next turn. Constructs and Undead are immune to the slowed condition inflicted by this spell.
+  duration: up to 1 round
+  higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
+  level: 1
+  name: Sapping Strike
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - magus
+    - necromancy
+    - smite
 scatter:
   casting_time: 1 standard action
   components: V
@@ -7151,8 +7477,10 @@ scorching_blast:
     - XGE
   tags:
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - fire
 scorching_ray:
   casting_time: 1 standard action
   components: V, S
@@ -7170,8 +7498,10 @@ scorching_ray:
     - PHB
   tags:
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - fire
 scrying:
   casting_time: 10 minutes
   components: V, S, M
@@ -7214,7 +7544,7 @@ searing_smite:
   components: V
   concentration: false
   description: Your weapon flares with white-hot intensity, and the triggering attack deals an extra 1d6 fire damage to the target and causes the target to ignite in flames. The flames deal ongoing_damage 1d6 fire damage (Constitution save ends). If the target or a creature within 5 feet of it uses a standard action to put out the flames, or if some other effect douses the flames (such as the target being submerged in water), the spell ends.
-  duration: 1 minute
+  duration: Up to 1 minute
   higher_level: When you cast this spell using a spell slot of 2nd level or higher, the initial extra damage dealt by the attack increases by 1d6 for each slot level above 1st.
   level: 1
   name: Searing Smite
@@ -7225,9 +7555,11 @@ searing_smite:
     - 2D
   tags:
     - evocation
+    - magus
     - paladin
     - ranger
     - smite
+    - fire
 secret_chest:
   casting_time: 1 standard action
   components: V, S, M
@@ -7267,6 +7599,7 @@ see_invisibility:
     - artificer
     - bard
     - divination
+    - magus
     - sorcerer
     - wizard
 seeming:
@@ -7329,6 +7662,7 @@ shadow_blade:
     - XGE
   tags:
     - illusion
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -7357,6 +7691,7 @@ shape_water:
     - sorcerer
     - transmutation
     - wizard
+    - water
 shapechange:
   casting_time: 1 standard action
   components: V, S, M
@@ -7418,6 +7753,7 @@ shield:
     - 2D
   tags:
     - abjuration
+    - magus
     - sorcerer
     - wizard
 shield_of_faith:
@@ -7468,8 +7804,11 @@ shocking_grasp:
   tags:
     - artificer
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - air
+    - fire
 sickening_radiance:
   casting_time: 1 standard action
   components: V, S
@@ -7529,6 +7868,7 @@ silent_image:
   tags:
     - bard
     - illusion
+    - magus
     - sorcerer
     - wizard
 simulacrum:
@@ -7618,6 +7958,7 @@ sleet_storm:
     - druid
     - sorcerer
     - wizard
+    - water
 slow:
   casting_time: 1 standard action
   components: V, S, M
@@ -7639,6 +7980,7 @@ slow:
     - 4C
   tags:
     - bard
+    - magus
     - sorcerer
     - transmutation
     - wizard
@@ -7660,6 +8002,7 @@ snow_flurry:
     - evocation
     - sorcerer
     - wizard
+    - water
 soul_cage:
   casting_time: 1 reaction, which you take when a humanoid you can see within 60 feet of you dies
   components: V, S, M
@@ -7779,6 +8122,7 @@ spider_climb:
     - PHB
   tags:
     - artificer
+    - magus
     - sorcerer
     - transmutation
     - warlock
@@ -7822,27 +8166,6 @@ spirit_guardians:
   tags:
     - conjuration
     - paladin
-spirit_shroud:
-  casting_time: 1 minor action
-  components: V, S
-  concentration: true
-  description: |-
-    You call forth spirits of the dead, which flit around you to a distance of 10 feet for the spell's duration. The spirits are intangible and invulnerable.
-
-    When you cast this spell, you can designate any number of creatures you can see to be unaffected by it. An affected creature can't regain hit points while in the area, and when the creature enters the area for the first time on a turn or starts its turn there, it must make a Wisdom saving throw. On a failed save, it loses all of its temporary hit points.
-  duration: Up to 1 minute
-  level: 3
-  name: Spirit Shroud
-  range: Self
-  sources:
-    - TCE
-    - 2D
-  tags:
-    - cleric
-    - necromancy
-    - paladin
-    - warlock
-    - wizard
 spiritual_weapon:
   casting_time: 1 minor action
   components: V, S
@@ -7879,6 +8202,7 @@ staggering_smite:
   tags:
     - evocation
     - paladin
+    - magus
     - smite
 steel_wind_strike:
   casting_time: 1 standard action
@@ -7898,6 +8222,7 @@ steel_wind_strike:
     - 2D
   tags:
     - conjuration
+    - magus
     - ranger
     - wizard
 stinking_cloud:
@@ -7957,6 +8282,7 @@ stoneskin:
     - abjuration
     - artificer
     - druid
+    - magus
     - ranger
     - sorcerer
     - wizard
@@ -7987,6 +8313,9 @@ storm_of_vengeance:
   tags:
     - conjuration
     - druid
+    - air
+    - fire
+    - water
 storm_sphere:
   casting_time: 1 standard action
   components: V, S
@@ -8009,6 +8338,8 @@ storm_sphere:
     - evocation
     - sorcerer
     - wizard
+    - air
+    - fire
 suggestion:
   casting_time: 1 standard action
   components: V, M
@@ -8344,6 +8675,7 @@ sword_burst:
   tags:
     - artificer
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -8434,9 +8766,27 @@ telekinesis:
   sources:
     - PHB
   tags:
+    - magus
     - sorcerer
     - transmutation
     - wizard
+telekinetic_grip:
+  casting_time: foo
+  components: V, S
+  concentration: false
+  description: |-
+    You attempt to bind a creature with telekinetic force. The target must succeed on a Strength saving throw or be pulled to an unoccupied space within 5 feet of you and be slowed until the start of your next turn.
+
+    If the target is willing, they may forgo the saving throw and not be subjected to the slowed condition.
+  duration: up to 1 round
+  level: 1
+  name: Telekinetic Grip
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - magus
+    - transmutation
 telepathic_bond:
   casting_time: 1 standard action
   components: V, S, M
@@ -8633,6 +8983,7 @@ thunder_step:
     - XGE
   tags:
     - conjuration
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -8656,9 +9007,11 @@ thunderclap:
     - bard
     - druid
     - evocation
+    - magus
     - sorcerer
     - warlock
     - wizard
+    - air
 thunderous_smite:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
@@ -8674,7 +9027,9 @@ thunderous_smite:
   tags:
     - evocation
     - paladin
+    - magus
     - smite
+    - air
 thunderwave:
   casting_time: 1 standard action
   components: V, S
@@ -8694,8 +9049,10 @@ thunderwave:
     - bard
     - druid
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - air
 tidal_wave:
   casting_time: 1 standard action
   components: V, S, M
@@ -8714,6 +9071,7 @@ tidal_wave:
     - druid
     - sorcerer
     - wizard
+    - water
 time_stop:
   casting_time: 1 standard action
   components: V
@@ -8817,6 +9175,8 @@ transmute_rock:
     - druid
     - transmutation
     - wizard
+    - earth
+    - water
 transport_via_plants:
   casting_time: 1 standard action
   components: V, S
@@ -8928,6 +9288,7 @@ true_strike:
   tags:
     - bard
     - divination
+    - magus
     - sorcerer
     - warlock
     - wizard
@@ -8952,6 +9313,7 @@ tsunami:
   tags:
     - conjuration
     - druid
+    - water
 unseen_servant:
   casting_time: 1 standard action
   components: V, S, M
@@ -9051,6 +9413,7 @@ wall_of_fire:
     - evocation
     - sorcerer
     - wizard
+    - fire
 wall_of_force:
   casting_time: 1 standard action
   components: V, S, M
@@ -9093,6 +9456,7 @@ wall_of_ice:
   tags:
     - evocation
     - wizard
+    - water
 wall_of_light:
   casting_time: 1 standard action
   components: V, S, M
@@ -9134,6 +9498,7 @@ wall_of_sand:
   tags:
     - evocation
     - wizard
+    - earth
 wall_of_stone:
   casting_time: 1 standard action
   components: V, S, M
@@ -9163,6 +9528,7 @@ wall_of_stone:
     - evocation
     - sorcerer
     - wizard
+    - earth
 wall_of_thorns:
   casting_time: 1 standard action
   components: V, S, M
@@ -9205,6 +9571,7 @@ wall_of_water:
     - evocation
     - sorcerer
     - wizard
+    - water
 warding_bond:
   casting_time: 1 standard action
   components: V, S, M
@@ -9249,8 +9616,10 @@ warding_wind:
     - bard
     - druid
     - evocation
+    - magus
     - sorcerer
     - wizard
+    - air
 water_breathing:
   casting_time: 1 standard action
   components: V, S, M
@@ -9320,6 +9689,7 @@ watery_sphere:
     - druid
     - sorcerer
     - wizard
+    - water
 web:
   casting_time: 1 standard action
   components: V, S, M
@@ -9344,6 +9714,7 @@ web:
   tags:
     - artificer
     - conjuration
+    - magus
     - sorcerer
     - wizard
 weird:
@@ -9386,6 +9757,7 @@ whirlwind:
     - evocation
     - sorcerer
     - wizard
+    - air
 wind_walk:
   casting_time: 1 minute
   components: V, S, M
@@ -9425,6 +9797,7 @@ wind_wall:
     - druid
     - evocation
     - ranger
+    - air
 witch_bolt:
   casting_time: 1 standard action
   components: V, S, M
@@ -9444,6 +9817,8 @@ witch_bolt:
     - sorcerer
     - warlock
     - wizard
+    - air
+    - fire
 word_of_radiance:
   casting_time: 1 standard action
   components: V, M
@@ -9519,6 +9894,27 @@ wrathful_smite:
     - evocation
     - paladin
     - smite
+zapping_strike:
+  casting_time: 1 free action, which you take when you hit with a melee weapon attack
+  components: V
+  concentration: false
+  description: |-
+    Electricity crackles about your weapon. The target, as well as one other creature of your choice within 15 feet of the initial target, take 1d6 lightning damage.
+
+    Immediately after the attack, you may choose to teleport to an unoccupied space within 5 feet of the target of the lightning bounce.
+  duration: Instantaneous
+  higher_level: If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.
+  level: 1
+  name: Zapping Strike
+  range: Self
+  sources:
+    - 2D
+  tags:
+    - conjuration
+    - magus
+    - smite
+    - air
+    - fire
 zephyr_strike:
   casting_time: 1 minor action
   components: V
@@ -9534,5 +9930,7 @@ zephyr_strike:
   sources:
     - XGE
   tags:
+    - magus
     - ranger
     - transmutation
+    - air

--- a/spells.yml
+++ b/spells.yml
@@ -6801,7 +6801,7 @@ prestidigitation:
   tags:
     - artificer
     - bard
-    - prestidigitation
+    - magus
     - sorcerer
     - transmutation
     - warlock


### PR DESCRIPTION
These changes introduce the following tags:
- **magus**
- **air**
- **earth**
- **fire**
- **water**

In addition, the following new spells are introduced:
- **_arcane weapon_** (artificer, magus)
- **_blazing strike_** (magus)
- **_divine smite_** (paladin)
- **_eldritch smite_** (warlock)
- **_ethereal strike_** (magus)
- **_frost strike_** (magus)
- **_quaking blow_** (artificer, magus, sorcerer, warlock)
- **_rime blade_** (artificer, magus, sorcerer, warlock)
- **_sapping strike_** (magus)
- **_telekinetic grip_** (magus)
- **_zapping strike_** (magus)