### PR TITLE
Cantrips now deal half damage on a successful save

### DIFF
--- a/spells.yml
+++ b/spells.yml
@@ -8695,7 +8695,7 @@ storm_of_vengeance:
 
     **Torrential Rain.** A deluge of water pours from the sky. Any open fires in the area are extinguished, the ground becomes difficult terrain for 1 minute, and any holes less than 10 feet deep are filled with water. The area is heavily obscured by the driving rain until the start of your next turn.
 
-    **Crashing Lightning.** Tremendous bolts of lightning strike up to six points beneath the cloud of your choice that you can see. Each creature or object within 5 feet of one or more points must succeed on a Dexterity saving throw or take 10d6 lightning damage, or half as much damage on a successful one. Additionally, each creature within 100 feet of one or more points must succeed on a Constitution saving throw or take 2d6 thunder damage and become deafened for 5 minutes.
+    **Crashing Lightning.** Tremendous bolts of lightning strike up to six points beneath the cloud of your choice that you can see. Each creature or object within 5 feet of one or more points must make a Dexterity saving throw. A creature takes 10d6 lightning damage on a failed save, or half as much damage on a successful one. Additionally, each creature within 100 feet of one or more points must succeed on a Constitution saving throw or take 2d6 thunder damage and become deafened for 5 minutes.
 
     **Pounding Hail.** Massive hailstones fall from the clouds. Until the start of your next turn, each creature that starts its turn in the area or that enters it for the first time on a turn takes 2d6 bludgeoning damage, and the ground becomes difficult terrain for 1 minute.
 

--- a/spells.yml
+++ b/spells.yml
@@ -46,7 +46,7 @@ acid_splash:
   components: V, S
   concentration: false
   description: |-
-    You hurl a bubble of acid. Choose one creature you can see within range, or choose two creatures you can see within range that are within 5 feet of each other. A target must succeed on a Dexterity saving throw or take 1d6 acid damage.
+    You hurl a bubble of acid. Choose one creature you can see within range, or choose two creatures you can see within range that are within 5 feet of each other. Each target must make a Dexterity saving throw. A target takes 1d6 acid damage on a failed save, or half as much damage on a successful save.
 
     This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -1925,7 +1925,7 @@ create_bonfire:
   components: V, S
   concentration: true
   description: |-
-    You create a bonfire on ground that you can see within range. Until the spell ends, the magic bonfire fills a 5-foot cube. Any creature in the bonfire's space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage. A creature must also make the saving throw when it moves into the bonfire's space for the first time on a turn or ends its turn there.
+    You create a bonfire on ground that you can see within range. Until the spell ends, the magic bonfire fills a 5-foot cube. Any creature in the bonfire's space when you cast the spell must make a Dexterity saving throw. A creature takes 1d8 fire damage on a failed save, or half as much on a successful one. A creature must also make the saving throw when it moves into the bonfire's space for the first time on a turn or ends its turn there.
 
     The bonfire ignites flammable objects in its area that aren't being worn or carried.
 
@@ -4103,7 +4103,7 @@ frostbite:
   components: V, S
   concentration: false
   description: |-
-    You cause numbing frost to form on one creature that you can see within range. The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn.
+    You cause numbing frost to form on one creature that you can see within range. The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn. On a successful save, the target takes half as much damage and suffers no other effects.
 
     The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -5293,7 +5293,7 @@ infestation:
   components: V, S, M
   concentration: false
   description: |-
-    You cause a cloud of mites, fleas, and other parasites to appear momentarily on one creature you can see within range. The target must succeed on a Constitution saving throw, or it takes 1d6 poison damage and, if its speed is at least 5 feet, it moves 5 feet in a random direction. Roll a d4 for the direction: 1, north; 2, south; 3, east; or 4, west. This movement doesn't provoke opportunity attacks, and if the direction rolled is blocked, the target doesn't move.
+    You cause a cloud of mites, fleas, and other parasites to appear momentarily on one creature you can see within range. The target must make a Constitution saving throw. On a failed save, it takes 1d6 poison damage and, if its speed is at least 5 feet, it moves 5 feet in a random direction. Roll a d4 for the direction: 1, north; 2, south; 3, east; or 4, west. This movement doesn't provoke opportunity attacks, and if the direction rolled is blocked, the target doesn't move. On a successful save, it takes half as much damage and does not move.
 
     The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -5735,7 +5735,7 @@ lightning_lure:
   components: V
   concentration: false
   description: |-
-    You create a lash of lightning energy that strikes at one creature of your choice that you can see within 15 feet of you. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you.
+    You create a lash of lightning energy that strikes at one creature of your choice that you can see within 15 feet of you. The target must make a Strength saving throw. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you.
 
     This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
   duration: Instantaneous
@@ -6325,7 +6325,7 @@ mind_sliver:
   components: V
   concentration: false
   description: |-
-    You drive a disorienting spike of psychic energy into the mind of one creature you can see within range. The target must succeed on an Intelligence saving throw or take 1d6 psychic damage and subtract 1d4 from the next saving throw it makes before the end of your next turn.
+    You drive a disorienting spike of psychic energy into the mind of one creature you can see within range. The target must make an Intelligence saving throw. On a failed save, it takes 1d6 psychic damage and subtracts 1d4 from the next saving throw it makes until the end of your next turn. On a successful save, it takes half as much damage and suffers no other effect.
 
     This spell's damage increases by 1d6 when you reach certain levels: 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: 1 round
@@ -6961,7 +6961,7 @@ poison_spray:
   components: V, S
   concentration: false
   description: |-
-    You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must succeed on a Constitution saving throw or take 1d12 poison damage.
+    You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must make a Constitution saving throw. On a failed save, it takes 1d12 poison damage, or half as much on a successful one.
 
     This spell's damage increases by 1d12 when you reach 5th level (2d12), 11th level (3d12), and 17th level (4d12).
   duration: Instantaneous
@@ -7721,7 +7721,7 @@ sacred_flame:
   components: V, S
   concentration: false
   description: |-
-    Flame-like radiance descends on a creature that you can see within range. The target must succeed on a Dexterity saving throw or take 1d8 radiant damage. The target gains no benefit from cover for this saving throw.
+    Flame-like radiance descends on a creature that you can see within range. The target must make a Dexterity saving throw. On a failed save, it takes 1d8 radiant damage, or half as much on a successful one. The target gains no benefit from cover for this saving throw.
 
     The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
   duration: Instantaneous
@@ -9075,7 +9075,7 @@ sword_burst:
   components: V
   concentration: false
   description: |-
-    You create a momentary circle of spectral blades that sweep around you. All other creatures within 5 feet of you must each succeed on a Dexterity saving throw or take 1d6 force damage.
+    You create a momentary circle of spectral blades that sweep around you. All other creatures within 5 feet of you must make a Dexterity saving throw. On a failed save, a creature takes 1d6 force damage, or half as much on a successful one.
 
     This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -9417,7 +9417,7 @@ thunderclap:
   components: S
   concentration: false
   description: |-
-    You create a burst of thunderous sound that can be heard up to 100 feet away. Each creature within range, other than you, must succeed on a Constitution saving throw or take 1d6 thunder damage.
+    You create a burst of thunderous sound that can be heard up to 100 feet away. Each other creature within range must make a Constitution saving throw. On a failed save, a creature takes 1d6 thunder damage, or half as much on a successful one.
 
     The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -9546,9 +9546,9 @@ toll_the_dead:
   components: V, S
   concentration: false
   description: |-
-    You point at one creature you can see within range, and the sound of a dolorous bell fills the air around it for a moment. The target must succeed on a Wisdom saving throw or take 1d8 necrotic damage. If the target is missing any of its hit points, it instead takes 1d12 necrotic damage.
+    You point at one creature you can see within range, and the sound of a dolorous bell fills the air around it for a moment. The target must make a Wisdom saving throw. On a failed save, it takes 1d6 necrotic damage. If the target is missing any of its hit points, it instead takes 1d10 necrotic damage. On a successful save, the target takes half as much damage.
 
-    The spell's damage increases by one die when you reach 5th level (2d8 or 2d12), 11th level (3d8 or 3d12), and 17th level (4d8 or 4d12).
+    The spell's damage increases by one die when you reach 5th level (2d6 or 2d10), 11th level (3d6 or 3d10), and 17th level (4d6 or 4d10).
   duration: Instantaneous
   level: 0
   name: Toll the Dead
@@ -9803,9 +9803,9 @@ vicious_mockery:
   components: V
   concentration: false
   description: |-
-    You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.
+    You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must make a Wisdom saving throw. On a failed save, it takes 1d4 psychic damage and has disadvantage on the next attack roll it makes before the end of its next turn. On a successful save, it takes half as much damage and suffers no other effects.
 
-    This spell's damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).
+    This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
   level: 0
   name: Vicious Mockery
@@ -10288,7 +10288,7 @@ word_of_radiance:
   components: V, M
   concentration: false
   description: |-
-    You utter a divine word, and burning radiance erupts from you. Each creature of your choice that you can see within range must succeed on a Constitution saving throw or take 1d6 radiant damage.
+    You utter a divine word, and burning radiance erupts from you. Each other creature of your choice that you can see within range must make a Constution saving throw. On a failed save, a creature takes 1d6 radiant damage, or half as much on a successful one.
 
     The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous

--- a/spells.yml
+++ b/spells.yml
@@ -1925,7 +1925,7 @@ create_bonfire:
   components: V, S
   concentration: true
   description: |-
-    You create a bonfire on ground that you can see within range. Until the spell ends, the magic bonfire fills a 5-foot cube. Any creature in the bonfire's space when you cast the spell must make a Dexterity saving throw. A creature takes 1d8 fire damage on a failed save, or half as much on a successful one. A creature must also make the saving throw when it moves into the bonfire's space for the first time on a turn or ends its turn there.
+    You create a bonfire on ground that you can see within range. Until the spell ends, the magic bonfire fills a 5-foot cube. Any creature in the bonfire's space when you cast the spell must make a Dexterity saving throw. A creature takes 1d8 fire damage on a failed save, or half as much damage on a successful one. A creature must also make the saving throw when it moves into the bonfire's space for the first time on a turn or ends its turn there.
 
     The bonfire ignites flammable objects in its area that aren't being worn or carried.
 
@@ -4945,7 +4945,7 @@ hex:
   duration: Up to 1 hour
   higher_level: When you cast this spell using a spell slot of 3rd or 4th level, you can maintain your concentration on the spell for up to 8 hours. When you use a spell slot of 5th level or higher, you can maintain your concentration on the spell for up to 24 hours.
   level: 1
-  material: the [petrified]($glossary/conditions#) eye of a newt
+  material: the petrified eye of a newt
   name: Hex
   range: 90 feet
   sources:
@@ -5174,7 +5174,7 @@ immolation:
   components: V
   concentration: false
   description: |-
-    Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 10d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns indefinitely, taking ongoing_damage 5d6 fire damage (save ends). The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. These magical flames can't be extinguished by nonmagical means.
+    Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 10d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns indefinitely, taking ongoing 5d6 fire damage (save ends). The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. These magical flames can't be extinguished by nonmagical means.
 
     If damage from this spell kills a target, the target is turned to ash.
   duration: Instantaneous
@@ -5293,7 +5293,7 @@ infestation:
   components: V, S, M
   concentration: false
   description: |-
-    You cause a cloud of mites, fleas, and other parasites to appear momentarily on one creature you can see within range. The target must make a Constitution saving throw. On a failed save, it takes 1d6 poison damage and, if its speed is at least 5 feet, it moves 5 feet in a random direction. Roll a d4 for the direction: 1, north; 2, south; 3, east; or 4, west. This movement doesn't provoke opportunity attacks, and if the direction rolled is blocked, the target doesn't move. On a successful save, it takes half as much damage and does not move.
+    You cause a cloud of mites, fleas, and other parasites to appear momentarily on one creature you can see within range. The target must make a Constitution saving throw. On a failed save, it takes 1d6 poison damage and, if its speed is at least 5 feet, it moves 5 feet in a random direction. Roll a d4 for the direction: 1, north; 2, south; 3, east; or 4, west. This movement doesn't provoke opportunity attacks, and if the direction rolled is blocked, the target doesn't move. On a successful save, it takes half as much damage and doesn't move.
 
     The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -5735,7 +5735,7 @@ lightning_lure:
   components: V
   concentration: false
   description: |-
-    You create a lash of lightning energy that strikes at one creature of your choice that you can see within 15 feet of you. The target must make a Strength saving throw. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you.
+    You create a lash of lightning energy that strikes at one creature of your choice that you can see within 15 feet of you. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you.
 
     This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
   duration: Instantaneous
@@ -6325,7 +6325,7 @@ mind_sliver:
   components: V
   concentration: false
   description: |-
-    You drive a disorienting spike of psychic energy into the mind of one creature you can see within range. The target must make an Intelligence saving throw. On a failed save, it takes 1d6 psychic damage and subtracts 1d4 from the next saving throw it makes until the end of your next turn. On a successful save, it takes half as much damage and suffers no other effect.
+    You drive a disorienting spike of psychic energy into the mind of one creature you can see within range. The target must make an Intelligence saving throw. On a failed save, it takes 1d6 psychic damage and subtracts 1d4 from the next saving throw it makes before the end of your next turn. On a successful save, it takes half as much damage and suffers no other effect.
 
     This spell's damage increases by 1d6 when you reach certain levels: 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: 1 round
@@ -6808,7 +6808,7 @@ phantasmal_killer:
   casting_time: 1 standard action
   components: V, S
   concentration: true
-  description: You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a Wisdom saving throw. On a failed save, the target becomes frightened and takes ongoing_damage 4d10 psychic damage for the duration (save ends).
+  description: You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a Wisdom saving throw. On a failed save, the target becomes frightened and takes ongoing 4d10 psychic damage for the duration (save ends).
   duration: Up to 1 minute
   higher_level: When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d10 for each slot level above 4th.
   level: 4
@@ -6961,7 +6961,7 @@ poison_spray:
   components: V, S
   concentration: false
   description: |-
-    You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must make a Constitution saving throw. On a failed save, it takes 1d12 poison damage, or half as much on a successful one.
+    You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must make a Constitution saving throw. On a failed save, it takes 1d12 poison damage, or half as much damage on a successful one.
 
     This spell's damage increases by 1d12 when you reach 5th level (2d12), 11th level (3d12), and 17th level (4d12).
   duration: Instantaneous
@@ -7721,7 +7721,7 @@ sacred_flame:
   components: V, S
   concentration: false
   description: |-
-    Flame-like radiance descends on a creature that you can see within range. The target must make a Dexterity saving throw. On a failed save, it takes 1d8 radiant damage, or half as much on a successful one. The target gains no benefit from cover for this saving throw.
+    Flame-like radiance descends on a creature that you can see within range. The target must make a Dexterity saving throw. On a failed save, it takes 1d8 radiant damage, or half as much damage on a successful one. The target gains no benefit from cover for this saving throw.
 
     The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
   duration: Instantaneous
@@ -7903,7 +7903,7 @@ searing_smite:
   casting_time: 1 free action, which you take when you hit with a melee weapon attack
   components: V
   concentration: false
-  description: Your weapon flares with white-hot intensity, and the triggering attack deals an extra 1d6 fire damage to the target and causes the target to ignite in flames. The flames deal ongoing_damage 1d6 fire damage (Constitution save ends). If the target or a creature within 5 feet of it uses a standard action to put out the flames, or if some other effect douses the flames (such as the target being submerged in water), the spell ends.
+  description: Your weapon flares with white-hot intensity, and the triggering attack deals an extra 1d6 fire damage to the target and causes the target to ignite in flames. The flames deal ongoing 1d6 fire damage (Constitution save ends). If the target or a creature within 5 feet of it uses a standard action to put out the flames, or if some other effect douses the flames (such as the target being submerged in water), the spell ends.
   duration: 1 minute
   higher_level: When you cast this spell using a spell slot of 2nd level or higher, the initial extra damage dealt by the attack increases by 1d6 for each slot level above 1st.
   level: 1
@@ -8695,7 +8695,7 @@ storm_of_vengeance:
 
     **Torrential Rain.** A deluge of water pours from the sky. Any open fires in the area are extinguished, the ground becomes difficult terrain for 1 minute, and any holes less than 10 feet deep are filled with water. The area is heavily obscured by the driving rain until the start of your next turn.
 
-    **Crashing Lightning.** Tremendous bolts of lightning strike up to six points beneath the cloud of your choice that you can see. Each creature or object within 5 feet of one or more points must succeed on a Dexterity saving throw or take 10d6 lightning damage, or half as much on a success. Additionally, each creature within 100 feet of one or more points must succeed on a Constitution saving throw or take 2d6 thunder damage and become deafened for 5 minutes.
+    **Crashing Lightning.** Tremendous bolts of lightning strike up to six points beneath the cloud of your choice that you can see. Each creature or object within 5 feet of one or more points must succeed on a Dexterity saving throw or take 10d6 lightning damage, or half as much damage on a successful one. Additionally, each creature within 100 feet of one or more points must succeed on a Constitution saving throw or take 2d6 thunder damage and become deafened for 5 minutes.
 
     **Pounding Hail.** Massive hailstones fall from the clouds. Until the start of your next turn, each creature that starts its turn in the area or that enters it for the first time on a turn takes 2d6 bludgeoning damage, and the ground becomes difficult terrain for 1 minute.
 
@@ -9075,7 +9075,7 @@ sword_burst:
   components: V
   concentration: false
   description: |-
-    You create a momentary circle of spectral blades that sweep around you. All other creatures within 5 feet of you must make a Dexterity saving throw. On a failed save, a creature takes 1d6 force damage, or half as much on a successful one.
+    You create a momentary circle of spectral blades that sweep around you. All other creatures within 5 feet of you must make a Dexterity saving throw. On a failed save, a creature takes 1d6 force damage, or half as much damage on a successful one.
 
     This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -9417,7 +9417,7 @@ thunderclap:
   components: S
   concentration: false
   description: |-
-    You create a burst of thunderous sound that can be heard up to 100 feet away. Each other creature within range must make a Constitution saving throw. On a failed save, a creature takes 1d6 thunder damage, or half as much on a successful one.
+    You create a burst of thunderous sound that can be heard up to 100 feet away. Each other creature within range must make a Constitution saving throw. On a failed save, a creature takes 1d6 thunder damage, or half as much damage on a successful one.
 
     The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous
@@ -10288,7 +10288,7 @@ word_of_radiance:
   components: V, M
   concentration: false
   description: |-
-    You utter a divine word, and burning radiance erupts from you. Each other creature of your choice that you can see within range must make a Constution saving throw. On a failed save, a creature takes 1d6 radiant damage, or half as much on a successful one.
+    You utter a divine word, and burning radiance erupts from you. Each other creature of your choice that you can see within range must make a Constution saving throw. On a failed save, a creature takes 1d6 radiant damage, or half as much damage on a successful one.
 
     The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
   duration: Instantaneous


### PR DESCRIPTION
As the title would suggest, cantrips now deal half damage on a successful save, with the exception of lightning lure. Since lightning lure only deals its damage if the target is pulled within 5 feet, it doesn't make much sense for it to still deal damage if it doesn't pull a creature to begin with.

Additionally, the following spells had damage tweaks:
- Toll the Dead now deals 1d6/1d10 damage, versus 1d8/1d12
- Vicious Mockery now deals 1d6 damage, versus 1d4

These changes reflect spell changes that already were present on the Rezia website.