### PR TITLE
Correct indentation in commune with nature

### DIFF
--- a/spells.yml
+++ b/spells.yml
@@ -1608,7 +1608,7 @@ commune_with_nature:
   description: |-
     You briefly become one with nature and gain knowledge of the surrounding territory. In the outdoors, the spell gives you knowledge of the land within 3 miles of you. In caves and other natural underground settings, the radius is limited to 300 feet. The spell doesn't function where nature has been replaced by construction, such as in dungeons and towns.
 
-     You instantly gain knowledge of up to three facts of your choice about any of the following subjects as they relate to the area:
+    You instantly gain knowledge of up to three facts of your choice about any of the following subjects as they relate to the area:
 
     - terrain and bodies of water
     - prevalent plants, minerals, animals, or peoples


### PR DESCRIPTION
The indentation in _commune with nature_ was off in the second paragraph. This fixes that.