### PR TITLE
Update "thrown" property listing

### DIFF
--- a/spells.yml
+++ b/spells.yml
@@ -8982,7 +8982,7 @@ shadow_blade:
   components: V, S
   concentration: true
   description: |-
-    You weave together threads of shadow to create a sword of solidified gloom in your hand. This magic sword lasts until the spell ends. It counts as a simple melee weapon with which you are proficient. It deals 1d8 psychic damage on a hit and has the finesse, light, and thrown properties (range 20/60). In addition, when you use the sword to attack a target that is in dim light or darkness, you make the attack roll with advantage.
+    You weave together threads of shadow to create a sword of solidified gloom in your hand. This magic sword lasts until the spell ends. It counts as a simple melee weapon with which you are proficient. It deals 1d8 psychic damage on a hit and has the finesse, light, and thrown (20/60 ft.) properties. In addition, when you use the sword to attack a target that is in dim light or darkness, you make the attack roll with advantage.
 
     If you drop the weapon or throw it, it dissipates at the end of the turn. Thereafter, while the spell persists, you can use a minor action to cause the sword to reappear in your hand.
   duration: Up to 1 minute


### PR DESCRIPTION
Instead of `thrown (range 20/60)`, write `thrown (20/60 ft.)`. It's shorter, has units, we can clarify the meaning with a popup for "thrown" (but it seems obvious enough), and it's more in line with other listing modifiers, like `light (20/60 ft.)` for illumination (coming in a future PR).

Only _shadow blade_ is actually affected in this PR, but this has wider implications.