### PR TITLE
Define link/popup syntax for markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,20 @@ The yaml style can be reproduced with `js-yaml` (https://www.npmjs.com/package/j
 
 Anywhere `markdown` is allowed in a yaml, the following syntax is allowed:
 ```md
-[displayed link text](source:file/key)
-[[displayed popup text]](source:file/key)
+[type:displayed text]($source:file.key)
 ```
 
-- The `displayed text` field is what is displayed to the user, exactly as-is. No markdown syntax is allowed within.
-- The number of square brackets, `[]` or `[[]]`, suggests whether a link or a popup should be generated, respectively.
-- The optional `source` field defaults to `2d`, which indicates that the content exists in the 2d standard. Arbitrary sources are permitted, but the expectation is that eventually all data will be standardized.
-- The `file` field indicates which yaml file the content exists in.
+- The optional `type:` field determines how this component is to be rendered. If omitted, it defaults to `popup:`. Compilers must recognize the following types:
+    - `popup`: render this component as a popup anchor
+    - `link`: render this component as a normal hyperlink
+- The `displayed text` field is the exact string that is displayed to the user.
+- The optional `source:` field instructs the compiler which directory to look in for content. If omitted, it defaults to `2d:`, which is currently the only source compilers must recognize.
+    - `2d`: the current version of the 2d standard
+- The `file` field is the name of the yaml file containing the content. It may include one or more `/`'s if the file is in a subdirectory, but it may not include a suffix, which is always assumed to be `.yml`.
 - The optional `key` field indicates the object's key in the yaml file. If not present, it is inferred to be the lowercase, snake_case, punctuation-free equivalent to the displayed text.
 
 > ### Example
-> The following is equivalent to `[[heroes' feast]](2d:spells/heroes_feast)`, which generates a popup anchor to the _heroes' feast_ spell:
-> ```md
-> You cast [[heroes' feast]](spells).
-> ```
+> `[heroes' feast]($spells)` is equivalent to `[popup:heroes' feast]($2d:spells.heroes_feast)`, which generates a popup to the _heroes' feast_ spell in `/path/to/2d/spells.yml`.
 
 ## Standard Object Structures
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ higher_level: markdown
 level: int
 range: string
 components: string
-material?: string
+material?: markdown
 duration: string
 concentration?: boolean
-casting_time: string
+casting_time: markdown
 tags: string[] # includes classes, school(s), domain(s), element?, curse?, ritual?
 sources: string[]
 ```
@@ -52,6 +52,6 @@ Feats are simply features as described in the aforementioned standard:
 ```yml
 name: string
 cost: string
-prerequisite?: string
+prerequisite?: markdown
 description: markdown
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ The standard object structure is given at https://docs.google.com/document/d/1Jm
 
 The yaml style can be reproduced with `js-yaml` (https://www.npmjs.com/package/js-yaml) using the dump options `{ sortKeys: true, lineWidth: Infinity }`.
 
+## Special Markdown Syntax
+
+Anywhere `markdown` is allowed in a yaml, the following syntax is allowed:
+```md
+[displayed link text](source:file/key)
+[[displayed popup text]](source:file/key)
+```
+
+- The `displayed text` field is what is displayed to the user, exactly as-is. No markdown syntax is allowed within.
+- The number of square brackets, `[]` or `[[]]`, suggests whether a link or a popup should be generated, respectively.
+- The optional `source` field defaults to `2d`, which indicates that the content exists in the 2d standard. Arbitrary sources are permitted, but the expectation is that eventually all data will be standardized.
+- The `file` field indicates which yaml file the content exists in.
+- The optional `key` field indicates the object's key in the yaml file. If not present, it is inferred to be the lowercase, snake_case, punctuation-free equivalent to the displayed text.
+
+> ### Example
+> The following is equivalent to `[[heroes' feast]](2d:spells/heroes_feast)`, which generates a popup anchor to the _heroes' feast_ spell:
+> ```md
+> You cast [[heroes' feast]](spells).
+> ```
+
 ## Standard Object Structures
 
 ### Spell


### PR DESCRIPTION
See the updated readme for details.

This PR also adds support for markdown in more places where linkable content might appear:
- Spell `material`: some materials may come from certain creature types, use certain items, be the results of other spells, etc.
- Spell `casting_time`: most spells don't need this, but reaction spells may involve linkable content in the trigger
- Feat `prerequisite`: many feats already require certain skill proficiencies or races