### PR TITLE
Define `Creature` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,30 +29,34 @@ Anywhere `markdown` is allowed in a yaml, the following syntax is allowed:
 
 ### Spell
 
-```yml
-name: string
-description: markdown
-higher_level: markdown
-level: int
-range: string
-components: string
-material?: markdown
-duration: string
-concentration?: boolean
-casting_time: markdown
-tags: string[] # includes classes, school(s), domain(s), element?, curse?, ritual?
-sources: string[]
+```ts
+type Spell = {
+    name: string
+    description: markdown
+    higher_level: markdown
+    level: uint
+    range: string
+    components: string
+    material?: markdown
+    duration: string
+    concentration?: boolean
+    casting_time: markdown
+    tags: string[] = [] // includes classes, school(s), domain(s), element?, curse?, ritual?
+    sources: string[]
+}
 ```
 
 ### Feat
 
 Feats are simply features as described in the aforementioned standard:
 
-```yml
-name: string
-cost: string
-prerequisite?: markdown
-description: markdown
+```ts
+type Feat = {
+    name: string
+    cost: string
+    prerequisite?: markdown
+    description: markdown
+}
 ```
 
 ### Creature

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ type Creature = {
     druid_level?: int
     proficiency_bonus?: int // overridden when rendered in “spell mode” to be “equals your proficiency bonus”
     ability_scores?: {
-        [ability in AbilityAcronym]?: int = 0
+        [ability in AbilityAbbreviation]?: int = 0
     } = {}
     speeds?: {
         [speed: string]: string // e.g. "walk: 30 ft."
@@ -80,7 +80,7 @@ type Creature = {
         [sense: string]: string // e.g. "darkvision: 60 ft."
     } = {}
     saves?: {
-        [ability in AbilityAcronym]?: float = 0 // final result = ability_scores[ability] + floor(proficiency_bonus * saves[ability])
+        [ability in AbilityAbbreviation]?: float = 0 // final result = ability_scores[ability] + floor(proficiency_bonus * saves[ability])
     } = {} 
     skills?: {
         [skill in Skill]?: float = 0 // same calculation as saves
@@ -154,5 +154,5 @@ In the above, `contextual_markdown` supports everything that `markdown` supports
 ```ts
 type Skill = "Acrobatics" | "Animal Handling" | "Arcana" | "Athletics" | "Deception" | "History" | "Insight" | "Intimidation" | "Investigation" | "Medicine" | "Nature" | "Perception" | "Performance" | "Persuasion" | "Religion" | "Sleight of Hand" | "Stealth"
 
-type AbilityAcronym = "str" | "dex" | "con" | "int" | "wis" | "cha"
+type AbilityAbbreviation = "str" | "dex" | "con" | "int" | "wis" | "cha"
 ```

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Anywhere `markdown` is allowed in a yaml, the following syntax is allowed:
 type Spell = {
     name: string
     description: markdown
-    higher_level: markdown
+    higher_level?: markdown
     level: uint
     range: string
     components: string
     material?: markdown
     duration: string
-    concentration?: boolean
+    concentration: boolean = false
     casting_time: markdown
     tags: string[] = [] // includes classes, school(s), domain(s), element?, curse?, ritual?
     sources: string[]
@@ -53,7 +53,7 @@ Feats are simply features as described in the aforementioned standard:
 ```ts
 type Feat = {
     name: string
-    cost: string
+    cost: int
     prerequisite?: markdown
     description: markdown
 }

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ type Spell = {
     components: string
     material?: markdown
     duration: string
-    concentration: boolean = false
+    concentration?: boolean = false
     casting_time: markdown
-    tags: string[] = [] // includes classes, school(s), domain(s), element?, curse?, ritual?
+    tags?: string[] = [] // includes classes, school(s), domain(s), element?, curse?, ritual?
     sources: string[]
 }
 ```
@@ -70,33 +70,33 @@ type Creature = {
     alignment?: string
     druid_level?: int
     proficiency_bonus?: int // overridden when rendered in “spell mode” to be “equals your proficiency bonus”
-    ability_scores: {
-        [ability: AbilityAcronym]: int = 0
+    ability_scores?: {
+        [ability in AbilityAcronym]?: int = 0
     } = {}
-    speeds: {
+    speeds?: {
         [speed: string]: string // e.g. "walk: 30 ft."
     } = {}
-    senses: {
+    senses?: {
         [sense: string]: string // e.g. "darkvision: 60 ft."
     } = {}
-    saves: {
-        [ability: AbilityAcronym]: float = 0 // final result = ability_scores[ability] + floor(proficiency_bonus * saves[ability])
+    saves?: {
+        [ability in AbilityAcronym]?: float = 0 // final result = ability_scores[ability] + floor(proficiency_bonus * saves[ability])
     } = {} 
-    skills: {
-        [skill: Skill]: float = 0 // same calculation as saves
+    skills?: {
+        [skill in Skill]?: float = 0 // same calculation as saves
     } = {}
-    languages: string[] = []
-    damage_resistances: string[] = []
-    damage_immunities: string[] = []
-    damage_vulnerabilities: string[] = []
-    condition_immunities: string[] = []
-    ac: int | string = 10 + ability_scores[dex]
-    hp: uint | string = hit_dice * (average(size_to_hit_die[size]) + ability_scores[con])
+    languages?: string[] = []
+    damage_resistances?: string[] = []
+    damage_immunities?: string[] = []
+    damage_vulnerabilities?: string[] = []
+    condition_immunities?: string[] = []
+    ac?: int | string = 10 + ability_scores[dex]
+    hp?: uint | string = hit_dice * (average(size_to_hit_die[size]) + ability_scores[con])
     hit_dice: uint | string // if this is a string, hp must be specified
-    traits: CreatureTrait[] = []
-    attacks: CreatureAttack[] = []
-    actions: CreatureAction[] = []
-    reactions: CreatureReaction[] = []
+    traits?: CreatureTrait[] = []
+    attacks?: CreatureAttack[] = []
+    actions?: CreatureAction[] = []
+    reactions?: CreatureReaction[] = []
     legendary_actions?: CreatureAction[]
     legendary_action_points?: uint | string = legendary_actions === undefined ? undefined : “1 legendary action point per player”
 }

--- a/README.md
+++ b/README.md
@@ -54,3 +54,93 @@ cost: string
 prerequisite?: markdown
 description: markdown
 ```
+
+### Creature
+
+```ts
+type Creature = {
+    name: string
+    size: CreatureSize
+    swarm_size?: CreatureSize
+    type: CreatureType
+    alignment?: string
+    druid_level?: int
+    proficiency_bonus?: int // overridden when rendered in “spell mode” to be “equals your proficiency bonus”
+    ability_scores: {
+        [abbreviated_ability]: int = 0
+    } = {}
+    speeds: {
+        [speed]: string // e.g. "walk: 30 ft."
+    } = {}
+    senses: {
+        [sense]: string // e.g. "darkvision: 60 ft."
+    } = {}
+    saves: {
+        [abbreviated_ability]: float = 0 // final result = ability_scores[stat] + floor(proficiency_bonus * saves[stat])
+    } = {} 
+    skills: {
+        [skill]: float = 0 // same calculation as saves
+    } = {}
+    languages: string[] = []
+    damage_resistances: string[] = []
+    damage_immunities: string[] = []
+    damage_vulnerabilities: string[] = []
+    condition_immunities: string[] = []
+    ac: int | string = 10 + ability_scores[dex]
+    hp: uint | string = hit_dice * (average(size_to_hit_die[size]) + ability_scores[con])
+    hit_dice: uint | string // if this is a string, hp must be specified
+    traits: CreatureTrait[] = []
+    attacks: CreatureAttack[] = []
+    actions: CreatureAction[] = []
+    reactions: CreatureReaction[] = []
+    legendary_actions?: CreatureAction[]
+    legendary_action_points?: uint | string = legendary_actions === undefined ? undefined : “1 legendary action point per player”
+}
+
+// where:
+
+type CreatureSize = "Minuscule" | "Tiny" | "Small" | "Medium" | "Large" | "Huge" | "Gargantuan"
+
+type CreatureType = "Aberration" | "Beast" | "Celestial" | "Construct" | "Dragon" | "Elemental" | "Fey" | "Fiend" | "Giant" | "Humanoid" | "Monstrosity" | "Ooze" | "Plant" | "Undead"
+
+type CreatureTrait = {
+    name: string
+    description: contextual_markdown
+}
+
+type CreatureAttack = {
+    name: string
+    proximity: "melee" | "ranged"
+    medium: "weapon" | "spell"
+    properties?: string[] = [] // e.g. ["finesse", "thrown (20/60 ft.)"]
+    hit: contextual_markdown
+}
+
+type CreatureAction = {
+    name: string
+    cost: int
+    description: contextual_markdown
+}
+
+type CreatureReaction = {
+    name: string
+    cost: uint // 0 => free reaction, 1 => normal reaction
+    trigger: contextual_markdown
+    description: contextual_markdown
+}
+```
+
+In the above, `contextual_markdown` supports everything that `markdown` supports in addition to the special "@" syntax below, which causes the item to be rendered differently depending on context. In this case, "context" means either as a typical DM-controlled creature, a creature summoned by a spell, or a druid's Wild Shape form (the latter two contexts are currently identical).
+- `@save({ability_score}, {ability_score})`
+    - first arg: kind of save the target makes
+    - second arg: stat used to set the DC
+    - renders as either e.g. “DC 14 Constitution saving throw” or “Constitution saving throw against your spell save DC”, depending on context
+    - example usage: “the target makes a @save(dex, cha) or takes 8d6 fire damage”
+- `@check({ability_score | skill}, {ability_score})`
+    - same as `@save`, but renders as either e.g. "DC 10 Athletics check" or "Athletics check against your spell save DC", depending on context
+- `@plus({ability_score})`
+    - renders as either e.g. “ - 1” or “ + your spellcasting ability score”, depending on context
+    - example usage: “1d8@plus(str) slashing damage”
+- in all of the above, the following values are allowed:
+    - ability_score: str, dex, con, int, wis, cha
+    - skill: acrobatics, animal_handling, arcana, athletics, deception, history, insight, intimidation, investigation, medicine, nature, perception, performance, persuasion, religion, sleight_of_hand, stealth

--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ type Creature = {
     druid_level?: int
     proficiency_bonus?: int // overridden when rendered in “spell mode” to be “equals your proficiency bonus”
     ability_scores: {
-        [abbreviated_ability]: int = 0
+        [ability: AbilityAcronym]: int = 0
     } = {}
     speeds: {
-        [speed]: string // e.g. "walk: 30 ft."
+        [speed: string]: string // e.g. "walk: 30 ft."
     } = {}
     senses: {
-        [sense]: string // e.g. "darkvision: 60 ft."
+        [sense: string]: string // e.g. "darkvision: 60 ft."
     } = {}
     saves: {
-        [abbreviated_ability]: float = 0 // final result = ability_scores[stat] + floor(proficiency_bonus * saves[stat])
+        [ability: AbilityAcronym]: float = 0 // final result = ability_scores[ability] + floor(proficiency_bonus * saves[ability])
     } = {} 
     skills: {
-        [skill]: float = 0 // same calculation as saves
+        [skill: Skill]: float = 0 // same calculation as saves
     } = {}
     languages: string[] = []
     damage_resistances: string[] = []
@@ -148,3 +148,11 @@ In the above, `contextual_markdown` supports everything that `markdown` supports
 - in all of the above, the following values are allowed:
     - ability_score: str, dex, con, int, wis, cha
     - skill: acrobatics, animal_handling, arcana, athletics, deception, history, insight, intimidation, investigation, medicine, nature, perception, performance, persuasion, religion, sleight_of_hand, stealth
+
+## Miscellaneous Types
+
+```ts
+type Skill = "Acrobatics" | "Animal Handling" | "Arcana" | "Athletics" | "Deception" | "History" | "Insight" | "Intimidation" | "Investigation" | "Medicine" | "Nature" | "Perception" | "Performance" | "Persuasion" | "Religion" | "Sleight of Hand" | "Stealth"
+
+type AbilityAcronym = "str" | "dex" | "con" | "int" | "wis" | "cha"
+```


### PR DESCRIPTION
Define the `Creature` type mostly as planned. There were a few simplifications in the @ syntax to make parsing easier, but that can be extended later as needed.

This standard is sufficient for all 4C creatures, and seems to work for all Rezia creature as well.

I also changed from specifying the types in yaml to pseudo-ts, so they're almost copy-pasteable.