### PR TITLE
Feats from MostlyMarble

### DIFF
--- a/feats.yml
+++ b/feats.yml
@@ -18,6 +18,13 @@ combat_medic:
   description: Accustomed to working in the heat of battle, you are particularly adept at healing. The Heal action is a minor action for you, and so is administering a potion or similar item to another creature.
   name: Combat Medic
   prerequisite: Proficiency in Medicine
+crossbow_expert:
+  cost: 4
+  description: |-
+    Thanks to extensive practice with the crossbow, you gain the following benefits:
+    - Being within 5 feet of a hostile creature doesn't impose disadvantage on your ranged attack rolls.
+    - When you take the Attack action and attack with a one-handed weapon, you can use a minor action to attack with a hand crossbow you are holding.
+  name: Crossbow Expert
 dual_wielder:
   cost: 4
   description: |-
@@ -26,10 +33,36 @@ dual_wielder:
     - When a creature you can see hits you with a melee weapon attack, you can attempt to parry the blow as a reaction. For each hand holding a light melee weapon that you're proficient with, add your proficiency bonus to your AC for that attack, potentially causing it to miss.
   name: Dual Wielder
   prerequisite: Proficiency with a light weapon
+eldritch_adept:
+  cost: 4
+  description: |-
+    Studying occult lore, you have unlocked eldritch power within yourself: you learn one Eldritch Invocation option of your choice from the warlock class. If the invocation has a prerequisite of any kind, you can choose that invocation only if you're a warlock who meets the prerequisite.
+
+    Whenever you gain a level, you can replace the invocation with another one from the warlock class.
+  name: Eldritch Adept
+  prerequisite: Spellcasting or Pact Magic feature
+elemental_adept:
+  cost: 1
+  description: |-
+    When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.
+
+    Spells you cast ignore resistance to damage of the chosen type. In addition, when you roll damage for a spell you cast that deals damage of that type, you can treat any 1 on a damage die as a 2.
+
+    You can select this feat multiple times. Each time you do so, you must choose a different damage type.
+  name: Elemental Adept
+  prerequisite: The ability to cast at least one spell
 expert:
   cost: 3
   description: Choose one skill or tool that you are proficient in. You gain expertise in that skill or tool.
   name: Expert
+fighting_initiate:
+  cost: 4
+  description: |-
+    Your martial training has helped you develop a particular style of fighting. As a result, you learn one Fighting Style option of your choice from the fighter class. If you already have a style, the one you choose must be different.
+
+    Whenever you reach a level that grants the Ability Score Improvement feature, you can replace this feat's fighting style with another one from the fighter class that you don't have.
+  name: Fighting Initiate
+  prerequisite: Proficiency with a martial weapon
 frightening:
   cost: 2
   description: You are especially menacing. When you take the Frighten action, you can target any number of creatures within range and within 20 feet of each other. When you do so, the saving throw DC to resist being frightened is your passive Intimidation.
@@ -44,6 +77,11 @@ heavily_armored:
   description: You gain proficiency with heavy armor and heavy shields.
   name: Heavily Armored
   prerequisite: Proficiency with medium armor
+heavy_armor_master:
+  cost: 3
+  description: You can use your armor to deflect strikes that would kill others. While you are wearing heavy armor, bludgeoning, piercing, and slashing damage is reduced by your proficiency bonus.
+  name: Heavy Armor Master
+  prerequisite: Proficiency with heavy armor
 infuriating:
   cost: 2
   description: You are especially irritating. When you take the Taunt action, you can target any number of creatures within range and within 20 feet of each other. When you do so, the saving throw DC to resist being taunted is your passive Deception, Performance, or Persuasion (your choice).
@@ -89,6 +127,22 @@ martial_adept:
     - You learn one maneuver of your choice from the fighter class.
     - If you don't already have a maneuver die, your maneuver die is a d4, and you can only use your chosen maneuver a number of times equal to your proficiency bonus. You regain expended uses when you finish a short rest or long rest.
   name: Martial Adept
+medium_armor_master:
+  cost: 2
+  description: |-
+    You have practiced moving in medium armor to gain the following benefits:
+    - You ignore the unstealthy property of medium armor.
+    - When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher.
+  name: Medium Armor Master
+  prerequisite: Proficiency with medium armor
+metamagic_adept:
+  cost: 4
+  description: |-
+    You've learned how to exert your will on your spells to alter how they function:
+    - You learn two Metamagic options of your choice from the sorcerer class. You can use only one Metamagic option on a spell when you cast it, unless the option says otherwise. Whenever you reach a level that grants the Ability Score Improvement feature, you can replace one of these Metamagic options with another one from the sorcerer class.
+    - You gain 2 sorcery points to spend on Metamagic (these points are added to any sorcery points you have from another source but can be used only on Metamagic). You regain all spent sorcery points when you finish a long rest.
+  name: Metamagic Adept
+  prerequisite: Spellcasting or Pact Magic feature
 mobile:
   cost: 3
   description: |-
@@ -121,6 +175,23 @@ ritual_caster:
     If you come across a spell in written form, such as a magical spell scroll or a wizard's spellbook, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell's level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell into your ritual book takes 2 hours per level of the spell, and costs 50 gp per level. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it.
   name: Ritual Caster
   prerequisite: Intelligence or Wisdom 1 or higher
+sentinel:
+  cost: 5
+  description: |-
+    You have mastered techniques to take advantage of every drop in any enemy's guard, gaining the following benefits:
+    - Creatures provoke an opportunity attack from you even if they take the Disengage action before leaving your reach.
+    - When you hit a creature with an opportunity attack, the creature's speed becomes 0 for the rest of the turn.
+    - When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn't have this feat), you can use a reaction to make a melee weapon attack against the attacking creature.
+  name: Sentinel
+shield_master:
+  cost: 3
+  description: |-
+    You have mastered advanced shield techniques. You gain the following benefits using a shield you're proficient with:
+    - Donning or doffing a shield costs 1 less action point than normal.
+    - You can use a make a special push attack using your shield. You are proficient with this attack, and it doesn't have the unarmed property. If you take the Attack action on your turn, you can make this attack as a minor action on the same turn.
+    - If you're wielding a shield and are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use a reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect.
+  name: Shield Master
+  prerequisite: Proficiency with shields
 skilled:
   cost: 2
   description: You gain proficiency in any combination of three skills or tools of your choice.
@@ -133,6 +204,38 @@ spell_sniper:
     - Your ranged spell attacks ignore half cover and three-quarters cover.
     - You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose from: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.
   name: Spell Sniper
+  prerequisite: The ability to cast at least one spell
+squat_nimbleness:
+  cost: 2
+  description: |-
+    You are uncommonly nimble for your race. You gain the following benefits:
+    - Increase your walking speed by 5 feet.
+    - You gain proficiency in Acrobatics or Athletics (your choice).
+    - You have advantage on Acrobatics checks made to escape being grappled.
+  name: Squat Nimbleness
+  prerequisite: Dwarf or a Small race
+telekinetic:
+  cost: 4
+  description: |-
+    You learn to move things with your mind, granting you the following benefits:
+    - You learn the [mage hand]($spells) cantrip. You can cast it without verbal or somatic components, and you can make the spectral hand invisible. If you already know this spell, its range increases by 30 feet when you cast it. Its spellcasting ability is Intelligence, Wisdom, or Charisma (choose when you select this feat).
+    - As a minor action, you can try to telekinetically shove one creature you can see within 30 feet of you. When you do so, the target must succeed on a Strength saving throw (DC 8 + your proficiency bonus + your Intelligence, Wisdom, or Charisma score, chosen when you select this feat) or be moved 5 feet toward you or away from you. A creature can willingly fail this save.
+  name: Telekinetic
+telepathic:
+  cost: 3
+  description: |-
+    You awaken the ability to mentally connect with others, granting you the following benefits:
+    - You can speak telepathically to any creature you can see within 60 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn't give the creature the ability to respond to you telepathically.
+    - You can cast the [detect thoughts]($spells) spell, requiring no spell slot or components, and you must finish a long rest before you can cast it this way again. Your spellcasting ability for the spell is Intelligence, Wisdom, or Charisma (choose when you select this feat). If you have spell slots of 2nd level or higher, you can cast this spell with them.
+  name: Telepathic
+war_caster:
+  cost: 5
+  description: |-
+    You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:
+    - You have advantage on Constitution saving throws that you make to maintain your concentration when you take damage.
+    - You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.
+    - When a hostile creature's movement provokes an opportunity attack from you, you can use a reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 standard action and must target only that creature.
+  name: War Caster
   prerequisite: The ability to cast at least one spell
 weapons_generalist:
   cost: 1

--- a/feats.yml
+++ b/feats.yml
@@ -13,6 +13,14 @@ athlete:
     - You gain a climb speed and a swim speed equal to your walk speed.
     - When you jump, your running start distance is halved.
   name: Athlete
+bow_master:
+  cost: 3
+  description: |-
+    As comfortable with a bow at close range as at long range, you gain the following benefits:
+    - You are proficient with arrows as melee weapons. For you, an arrow's damage die and type is 1d4 piercing, and it has the finesse property. Additionally, when you hit a creature with this attack, your movement doesn't provoke opportunity attacks from that creature for the rest of the turn.
+    - As a major action, you can make a single, precise ranged attack with a shortbow, longbow, or greatbow. The weapon's normal and long ranges are doubled for the attack, and it ignores half cover and three-quarters cover. You have advantage on the attack roll if the target is within the weapon's usual normal range.
+  name: Bow Master
+  prerequisite: Proficiency with shortbows, longbows, or greatbows
 brawler:
   cost: 2
   description: |-
@@ -40,6 +48,10 @@ crusher:
     - Once per turn, when you hit a target with a weapon that deals bludgeoning damage, you can move the target 5 feet to an unoccupied space, provided it is no more than one size larger than you.
     - When you score a critical hit with a weapon that deals bludgeoning damage to a target that's no more than one size larger than you, you can knock the target prone.
   name: Crusher
+divine_mark:
+  cost: 1
+  description: Your skin is permanently marked with a religious symbol. The appearance, location, and manner of acquisition of the symbol is up to you. It may be a birthmark you've always had, a tattoo you paid for, or a supernatural mark that appeared at some pivotal moment. Whatever its source, the mark counts as a holy symbol. Like similar holy symbols, it must be visible to be used as a spellcasting focus.
+  name: Divine Mark
 dual_wielder:
   cost: 4
   description: |-
@@ -237,6 +249,14 @@ sentinel:
     - When you hit a creature with an opportunity attack, the creature's speed becomes 0 for the rest of the turn.
     - When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn't have this feat), you can use a reaction to make a melee weapon attack against the attacking creature.
   name: Sentinel
+sharp_senses:
+  cost: 2
+  description: |-
+    As long as you can see and hear, you gain the following benefits:
+    - You don't suffer from passive Perception falloff.
+    - You have blindsight (5 ft.). If you already have blindsight from another source, the range of that blindsight is increased by 5 feet.
+  name: Sharp Senses
+  prerequisite: Proficiency in Perception
 shield_master:
   cost: 3
   description: |-
@@ -275,6 +295,14 @@ squat_nimbleness:
     - You have advantage on Acrobatics checks made to escape being grappled.
   name: Squat Nimbleness
   prerequisite: Dwarf or a Small race
+stick_fighter:
+  cost: 3
+  description: |-
+    You have practiced using both ends of a weapon to great effect. You gain the following benefits:
+    - After you take the Attack action to make a two-handed attack with a quarterstaff or spear, you can use a minor action to make another melee attack with the opposite end of the weapon. The weapon's damage die and type for this attack is 1d4 bludgeoning, and you must hold the weapon in two hands (you don't benefit from the weapon's versatile property for this attack).
+    - You gain a +1 bonus to AC while wielding a quarterstaff or spear with two hands.
+  name: Stick Fighter
+  prerequisite: Proficiency with quarterstaffs
 telekinetic:
   cost: 4
   description: |-
@@ -289,6 +317,24 @@ telepathic:
     - You can speak telepathically to any creature you can see within 60 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn't give the creature the ability to respond to you telepathically.
     - You can cast the [detect thoughts]($spells) spell, requiring no spell slot or components, and you must finish a long rest before you can cast it this way again. Your spellcasting ability for the spell is Intelligence, Wisdom, or Charisma (choose when you select this feat). If you have spell slots of 2nd level or higher, you can cast this spell with them.
   name: Telepathic
+torch_fighter:
+  cost: 1
+  description: |-
+    Darkness is all too common. Fortunately, you never go anywhere without a trusty torch. You gain the following benefits:
+    - Through magic, special gear, or some other means, you can light torches unbelievably quickly. You can take the Use action (1 AP) to light a torch you're holding. You don't need any tools or even a free hand to do so.
+    - You are proficient with torches as melee weapons. For you, a torch's damage die and type is 1d4 fire, and it has the finesse, light, and thrown (20/60 ft.) properties. 
+    - When you score a critical hit with a torch, the target is ignited (1d4; standard action ends) for 1 minute.
+  name: Torch Fighter
+variant_spells:
+  cost: 1
+  description: |-
+    When you gain this feat, choose one of the following damage types: acid, bludgeoning, cold, fire, lightning, piercing, poison, slashing, or thunder. Also choose a number of spells up to your proficiency bonus that deal damage of one of the listed types. When you cast one of the chosen spells, it deals damage of the chosen type instead of the listed type.
+
+    Additionally, for each chosen spell, you can change the saving throw associated with the damage. Both the original and new saving throw must be Strength, Dexterity, or Constitution.
+
+    Whenever you gain a level, you can replace one of the chosen spells with another, or choose an additional spell if the number of chosen spells is less than your proficiency bonus.
+  name: Variant Spells
+  prerequisite: The ability to cast at least one spell
 war_caster:
   cost: 5
   description: |-

--- a/feats.yml
+++ b/feats.yml
@@ -45,8 +45,7 @@ gladiator:
   prerequisite: Proficiency with shields
 heavily_armored:
   cost: 2
-  description: |-
-    You gain proficiency with heavy armor.
+  description: You gain proficiency with heavy armor and heavy shields.
   name: Heavily Armored
   prerequisite: Proficiency with medium armor
 infuriating:
@@ -64,8 +63,7 @@ keen_mind:
   prerequisite: Proficiency in Arcana, History, Investigation, Nature, or Religion
 lightly_armored:
   cost: 1
-  description: |-
-    You gain proficiency with light armor.
+  description: You gain proficiency with light armor and light shields.
   name: Lightly Armored
 mage_slayer:
   cost: 3
@@ -104,8 +102,7 @@ mobile:
   name: Mobile
 moderately_armored:
   cost: 2
-  description: |-
-    You gain proficiency with medium armor and shields.
+  description: You gain proficiency with medium armor and medium shields.
   name: Moderately Armored
   prerequisite: Proficiency with light armor
 powerful_build:

--- a/feats.yml
+++ b/feats.yml
@@ -79,12 +79,12 @@ magic_initiate:
   cost: 4
   description: |-
     You have trained to channel a specific domain of magic. Pick one of the following domains:
-    
-    **Arcane.** You learn the prestidigitation cantrip, plus two other cantrips and a 1st-level spell of your choice with the Arcane tag.
 
-    **Divine.** You learn the thaumaturgy cantrip, plus two other cantrips and a 1st-level spell of your choice with the Divine tag.
+    ***Arcane.*** You learn the [prestidigitation]($spells) cantrip, plus two other cantrips and a 1st-level spell of your choice with the Arcane tag.
 
-    **Primal.** You learn the druidcraft cantrip, plus two other cantrips and a 1st-level spell of your choice with the Primal tag.
+    ***Divine.*** You learn the [thaumaturgy]($spells) cantrip, plus two other cantrips and a 1st-level spell of your choice with the Divine tag.
+
+    ***Primal.*** You learn the [druidcraft]($spells) cantrip, plus two other cantrips and a 1st-level spell of your choice with the Primal tag.
 
     When you take this feat, choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells. You can cast the 1st-level spell without expending a spell slot a number of times equal to your proficiency bonus, regaining expended uses when you finish a long rest. You can also cast the 1st-level spell using any spell slots you have, as normal.
   name: Magic Initiate

--- a/feats.yml
+++ b/feats.yml
@@ -111,6 +111,11 @@ powerful_build:
     You are unusually bulky. You count as one size larger than your actual size for the purpose of grappling and being grappled, wielding heavy weapons, determining your carrying capacity, and determining the weight you can push, drag, or lift.
   name: Powerful Build
   prerequisite: Strength 2 or higher
+resilient:
+  cost: 3
+  description: |-
+    Choose one ability score. You gain proficiency in saving throws using the chosen ability.
+  name: Resilient
 ritual_caster:
   cost: 3
   description: |-
@@ -121,11 +126,11 @@ ritual_caster:
     If you come across a spell in written form, such as a magical spell scroll or a wizard's spellbook, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell's level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell into your ritual book takes 2 hours per level of the spell, and costs 50 gp per level. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it.
   name: Ritual Caster
   prerequisite: Intelligence or Wisdom 1 or higher
-resilient:
-  cost: 3
+skilled:
+  cost: 2
   description: |-
-    Choose one ability score. You gain proficiency in saving throws using the chosen ability.
-  name: Resilient
+    You gain proficiency in any combination of three skills or tools of your choice.
+  name: Skilled
 spell_sniper:
   cost: 4
   description: |-
@@ -135,11 +140,6 @@ spell_sniper:
     - You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose from: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.
   name: Spell Sniper
   prerequisite: The ability to cast at least one spell
-skilled:
-  cost: 2
-  description: |-
-    You gain proficiency in any combination of three skills or tools of your choice.
-  name: Skilled
 weapons_generalist:
   cost: 1
   description: |-

--- a/feats.yml
+++ b/feats.yml
@@ -15,8 +15,7 @@ athlete:
   name: Athlete
 combat_medic:
   cost: 2
-  description: |-
-    Accustomed to working in the heat of battle, you are particularly adept at healing. The Heal action is a minor action for you, and so is administering a potion to another creature.
+  description: Accustomed to working in the heat of battle, you are particularly adept at healing. The Heal action is a minor action for you, and so is administering a potion to another creature.
   name: Combat Medic
   prerequisite: Proficiency in Medicine
 dual_wielder:
@@ -29,8 +28,7 @@ dual_wielder:
   prerequisite: Proficiency with a light weapon
 expert:
   cost: 3
-  description: |-
-    Choose one skill or tool that you are proficient in. You gain expertise in that skill or tool.
+  description: Choose one skill or tool that you are proficient in. You gain expertise in that skill or tool.
   name: Expert
 frightening:
   cost: 2
@@ -39,8 +37,7 @@ frightening:
   prerequisite: Proficiency in Intimidation
 gladiator:
   cost: 4
-  description: |-
-    If you're wielding a shield when a creature misses you with a melee weapon attack, you can make a melee weapon attack against that creature as a reaction.
+  description: If you're wielding a shield when a creature misses you with a melee weapon attack, you can make a melee weapon attack against that creature as a reaction.
   name: Gladiator
   prerequisite: Proficiency with shields
 heavily_armored:
@@ -107,8 +104,7 @@ moderately_armored:
   prerequisite: Proficiency with light armor
 powerful_build:
   cost: 2
-  description: |-
-    You are unusually bulky. You count as one size larger than your actual size for the purpose of grappling and being grappled, wielding heavy weapons, determining your carrying capacity, and determining the weight you can push, drag, or lift.
+  description: You are unusually bulky. You count as one size larger than your actual size for the purpose of grappling and being grappled, wielding heavy weapons, determining your carrying capacity, and determining the weight you can push, drag, or lift.
   name: Powerful Build
   prerequisite: Strength 2 or higher
 resilient:
@@ -128,8 +124,7 @@ ritual_caster:
   prerequisite: Intelligence or Wisdom 1 or higher
 skilled:
   cost: 2
-  description: |-
-    You gain proficiency in any combination of three skills or tools of your choice.
+  description: You gain proficiency in any combination of three skills or tools of your choice.
   name: Skilled
 spell_sniper:
   cost: 4
@@ -142,6 +137,5 @@ spell_sniper:
   prerequisite: The ability to cast at least one spell
 weapons_generalist:
   cost: 1
-  description: |-
-    You have practiced with a variety of weapons. You gain proficiency with all simple and martial weapons.
+  description: You have practiced with a variety of weapons. You gain proficiency with all simple and martial weapons.
   name: Weapons Generalist

--- a/feats.yml
+++ b/feats.yml
@@ -37,9 +37,8 @@ frightening:
   prerequisite: Proficiency in Intimidation
 gladiator:
   cost: 4
-  description: If you're wielding a shield when a creature misses you with a melee weapon attack, you can make a melee weapon attack against that creature as a reaction.
+  description: If you're proficient with a shield you're wielding when a creature misses you with a melee weapon attack, you can make a melee weapon attack against that creature as a reaction.
   name: Gladiator
-  prerequisite: Proficiency with shields
 heavily_armored:
   cost: 2
   description: You gain proficiency with heavy armor and heavy shields.

--- a/feats.yml
+++ b/feats.yml
@@ -98,7 +98,7 @@ mobile:
   description: |-
     You are exceptionally speedy and agile. You gain the following benefits:
     - Your speed increases by 10 feet.
-    - When you use the Dash action, you gain the benefits of the Disengage action, and difficult terrain doesn't cost you extra movement on that turn.
+    - When you take the Dash action, you gain the benefits of the Disengage action, and difficult terrain doesn't cost you extra movement on that turn.
   name: Mobile
 moderately_armored:
   cost: 2

--- a/feats.yml
+++ b/feats.yml
@@ -104,7 +104,7 @@ grappler:
   description: |-
     An expert at grappling, you gain the following benefits:
     - You have advantage on attack rolls against a creature that is grappled by you.
-    - When you use grappling to move a creature and it tries to escape as a reaction, it has disadvantage on the saving throw.
+    - When you use grappling to move a creature and it tries to resist, it has disadvantage on the saving throw.
   name: Grappler
   prerequisite: Proficiency in Athletics
 heavily_armored:

--- a/feats.yml
+++ b/feats.yml
@@ -59,7 +59,7 @@ keen_mind:
   description: |-
     You can think quickly. You gain the following benefits:
     - You can take the Study action as a minor action.
-    - As long as nothing is preventing you from using reactions, you can use the Recognize Spell reaction without expending a reaction.
+    - The Recognize Spell reaction is a free reaction for you, and it doesn't count against your limit of 1 reaction per turn.
   name: Keen Mind
   prerequisite: Proficiency in Arcana, History, Investigation, Nature, or Religion
 lightly_armored:

--- a/feats.yml
+++ b/feats.yml
@@ -71,7 +71,7 @@ mage_slayer:
   cost: 3
   description: |-
     You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:
-    - When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.
+    - When a creature within 5 feet of you casts a spell, you can use a reaction to make a melee weapon attack against that creature.
     - When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.
     - You have advantage on saving throws against spells cast by creatures within 5 feet of you.
   name: Mage Slayer

--- a/feats.yml
+++ b/feats.yml
@@ -10,7 +10,7 @@ athlete:
   description: |-
     You have undergone extensive physical training to gain the following benefits:
     - When you are prone, standing up uses only 5 feet of your movement.
-    - You gain a climb speed equal to your walk speed.
+    - You gain a climb speed and a swim speed equal to your walk speed.
     - When you jump, your running start distance is halved.
   name: Athlete
 combat_medic:

--- a/feats.yml
+++ b/feats.yml
@@ -15,7 +15,7 @@ athlete:
   name: Athlete
 combat_medic:
   cost: 2
-  description: Accustomed to working in the heat of battle, you are particularly adept at healing. The Heal action is a minor action for you, and so is administering a potion to another creature.
+  description: Accustomed to working in the heat of battle, you are particularly adept at healing. The Heal action is a minor action for you, and so is administering a potion or similar item to another creature.
   name: Combat Medic
   prerequisite: Proficiency in Medicine
 dual_wielder:

--- a/feats.yml
+++ b/feats.yml
@@ -13,6 +13,14 @@ athlete:
     - You gain a climb speed and a swim speed equal to your walk speed.
     - When you jump, your running start distance is halved.
   name: Athlete
+brawler:
+  cost: 2
+  description: |-
+    Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:
+    - You are proficient with improvised weapons.
+    - The damage die of your unarmed strike is a d4.
+    - When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a minor action to make a grapple attack against the target.
+  name: Brawler
 combat_medic:
   cost: 2
   description: Accustomed to working in the heat of battle, you are particularly adept at healing. The Heal action is a minor action for you, and so is administering a potion or similar item to another creature.
@@ -25,6 +33,13 @@ crossbow_expert:
     - Being within 5 feet of a hostile creature doesn't impose disadvantage on your ranged attack rolls.
     - When you take the Attack action and attack with a one-handed weapon, you can use a minor action to attack with a hand crossbow you are holding.
   name: Crossbow Expert
+crusher:
+  cost: 3
+  description: |-
+    You are practiced in the art of crushing your enemies, granting you the following benefits:
+    - Once per turn, when you hit a target with a weapon that deals bludgeoning damage, you can move the target 5 feet to an unoccupied space, provided it is no more than one size larger than you.
+    - When you score a critical hit with a weapon that deals bludgeoning damage to a target that's no more than one size larger than you, you can knock the target prone.
+  name: Crusher
 dual_wielder:
   cost: 4
   description: |-
@@ -72,6 +87,14 @@ gladiator:
   cost: 4
   description: If you're proficient with a shield you're wielding when a creature misses you with a melee weapon attack, you can make a melee weapon attack against that creature as a reaction.
   name: Gladiator
+grappler:
+  cost: 3
+  description: |-
+    An expert at grappling, you gain the following benefits:
+    - You have advantage on attack rolls against a creature that is grappled by you.
+    - When you use grappling to move a creature and it tries to escape as a reaction, it has disadvantage on the saving throw.
+  name: Grappler
+  prerequisite: Proficiency in Athletics
 heavily_armored:
   cost: 2
   description: You gain proficiency with heavy armor and heavy shields.
@@ -99,6 +122,13 @@ lightly_armored:
   cost: 1
   description: You gain proficiency with light armor and light shields.
   name: Lightly Armored
+linguist:
+  cost: 1
+  description: |-
+    Through study or experience, you gain the following benefits:
+    - You learn three languages of your choice.
+    - You have a +5 bonus to Intelligence checks made to understand a language or dialect that you don't already know.
+  name: Linguist
 mage_slayer:
   cost: 3
   description: |-
@@ -155,6 +185,30 @@ moderately_armored:
   description: You gain proficiency with medium armor and medium shields.
   name: Moderately Armored
   prerequisite: Proficiency with light armor
+piercer:
+  cost: 3
+  description: |-
+    You have achieved a penetrating precision in combat, granting you the following benefits:
+    - Once per turn, when you hit a target with a weapon that deals piercing damage, you can reroll one of the weapon's damage dice. You must use the new roll.
+    - When you score a critical hit with a weapon that deals piercing damage, you can roll one additional weapon damage die when determining the extra piercing damage the target takes.
+  name: Piercer
+poisoner:
+  cost: 4
+  description: |-
+    You can prepare and deliver deadly poisons, granting you the following benefits:
+    - You know how to bypass a creature's defenses against poison. When you make a damage roll that deals poison damage, it ignores resistance to poison damage.
+    - When you take the Use action to apply poison to a weapon or piece of ammunition, it costs you 1 action point instead of 2, and you don't need a free hand to do so.
+    - You can make poison from virtually anything. With one hour of work using a poisoner's kit and an Intelligence (poisoner's kit) check, you can make a number of doses of makeshift poison equal to the the check's result divided by 5 (you still have to provide a container for the poison, such as a vial). Makeshift poison functions as basic poison, except it loses its potency after 8 hours and you add your poisoner's kit proficiency to the save DC.
+  name: Poisoner
+  prerequisite: Proficiency with the poisoner's kit
+polearm_master:
+  cost: 4
+  description: |-
+    You can keep your enemies at bay with reach weapons. You gain the following benefits:
+    - Creatures that are friendly to you don't count as cover for the purpose of melee attacks you make with glaives, halberds, and pikes.
+    - While you are wielding a spear, glaive, halberd, or pike, other creatures provoke an opportunity attack from you when they enter your reach.
+  name: Polearm Master
+  prerequisite: Proficiency with glaives, halberds, or pikes
 powerful_build:
   cost: 2
   description: You are unusually bulky. You count as one size larger than your actual size for the purpose of grappling and being grappled, wielding heavy weapons, determining your carrying capacity, and determining the weight you can push, drag, or lift.
@@ -196,6 +250,13 @@ skilled:
   cost: 2
   description: You gain proficiency in any combination of three skills or tools of your choice.
   name: Skilled
+slasher:
+  cost: 3
+  description: |-
+    You've learned where to cut to have the greatest results, granting you the following benefits:
+    - Once per turn when you hit a target with a melee weapon that deals slashing damage, you can choose one of the weapon's damage dice that rolled a 6 or lower, and a second target within the weapon's reach and within 5 feet of the first target. You graze the second target with the blow that hit the first, dealing slashing damage equal to the number on the chosen die.
+    - When you score a critical hit with a melee weapon that deals slashing damage, you can use the momentum of the strike to immediately make another attack with that weapon as part of the same action. You can't attack a target that you've already attacked as part of that action.
+  name: Slasher
 spell_sniper:
   cost: 4
   description: |-

--- a/feats.yml
+++ b/feats.yml
@@ -1,88 +1,87 @@
 alert:
-  name: Alert
   cost: 1
   description: |-
     Always on the lookout for danger, you gain the following benefits:
     - When you roll initiative, you can add your proficiency bonus to the roll.
     - Immediately after you roll initiative, you can swap your initiative with the initiative of one willing ally in the same combat. You can't make this swap if you or the ally is incapacitated.
+  name: Alert
 athlete:
-  name: Athlete
   cost: 2
   description: |-
     You have undergone extensive physical training to gain the following benefits:
     - When you are prone, standing up uses only 5 feet of your movement.
     - You gain a climb speed equal to your walk speed.
     - When you jump, your running start distance is halved.
+  name: Athlete
 combat_medic:
-  name: Combat Medic
   cost: 2
-  prerequisite: Proficiency in Medicine
   description: |-
     Accustomed to working in the heat of battle, you are particularly adept at healing. The Heal action is a minor action for you, and so is administering a potion to another creature.
+  name: Combat Medic
+  prerequisite: Proficiency in Medicine
 dual_wielder:
-  name: Dual Wielder
   cost: 4
-  prerequisite: Proficiency with a light weapon
   description: |-
     You master fighting with two weapons, gaining the following benefits:
     - When you attack a creature with a light weapon and miss, you gain advantage on the next attack you make with a different light weapon against that creature before the start of your next turn.
     - When a creature you can see hits you with a melee weapon attack, you can attempt to parry the blow as a reaction. For each hand holding a light melee weapon that you're proficient with, add your proficiency bonus to your AC for that attack, potentially causing it to miss.
+  name: Dual Wielder
+  prerequisite: Proficiency with a light weapon
 expert:
-  name: Expert
   cost: 3
   description: |-
     Choose one skill or tool that you are proficient in. You gain expertise in that skill or tool.
+  name: Expert
 frightening:
-  name: Frightening
   cost: 2
-  prerequisite: Proficiency in Intimidation
   description: |-
     You are especially menacing. When you take the Frighten action, you gain the following benefits:
     - You can target any number of creatures within range and within 20 feet of each other.
     - Instead of rolling for the Frighten DC, you can use your passive Intimidation. If you do so, the duration of the effect is save ends.
+  name: Frightening
+  prerequisite: Proficiency in Intimidation
 gladiator:
-  name: Gladiator
   cost: 4
-  prerequisite: Proficiency with shields
   description: |-
     If you're wielding a shield when a creature misses you with a melee weapon attack, you can make a melee weapon attack against that creature as a reaction.
+  name: Gladiator
+  prerequisite: Proficiency with shields
 heavily_armored:
-  name: Heavily Armored
   cost: 2
-  prerequisite: Proficiency with medium armor
   description: |-
     You gain proficiency with heavy armor.
+  name: Heavily Armored
+  prerequisite: Proficiency with medium armor
 infuriating:
-  name: Infuriating
   cost: 2
-  prerequisite: Proficiency in Deception, Performance, or Persuasion
   description: |-
     You are especially irritating. When you take the Taunt action, you gain the following benefits:
     - You can target any number of creatures within range and within 20 feet of each other.
     - Instead of rolling for the Taunt DC, you can use your passive Deception, Performance, or Persuasion. If you do so, the duration of the effect is save ends
+  name: Infuriating
+  prerequisite: Proficiency in Deception, Performance, or Persuasion
 keen_mind:
-  name: Keen Mind
   cost: 1
-  preerquisite: Proficiency in Arcana, History, Investigation, Nature, or Religion
   description: |-
     You can think quickly. You gain the following benefits:
     - You can take the Study action as a minor action.
     - As long as nothing is preventing you from using reactions, you can use the Recognize Spell reaction without expending a reaction.
+  name: Keen Mind
+  prerequisite: Proficiency in Arcana, History, Investigation, Nature, or Religion
 lightly_armored:
-  name: Lightly Armored
   cost: 1
   description: |-
     You gain proficiency with light armor.
+  name: Lightly Armored
 mage_slayer:
-  name: Mage Slayer
   cost: 3
   description: |-
     You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:
     - When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.
     - When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.
     - You have advantage on saving throws against spells cast by creatures within 5 feet of you.
+  name: Mage Slayer
 magic_initiate:
-  name: Magic Initiate
   cost: 4
   description: |-
     You have trained to channel a specific domain of magic. Pick one of the following domains:
@@ -94,63 +93,64 @@ magic_initiate:
     **Primal.** You learn the druidcraft cantrip, plus two other cantrips and a 1st-level spell of your choice with the Primal tag.
 
     When you take this feat, choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells. You can cast the 1st-level spell without expending a spell slot a number of times equal to your proficiency bonus, regaining expended uses when you finish a long rest. You can also cast the 1st-level spell using any spell slots you have, as normal.
+  name: Magic Initiate
 martial_adept:
-  name: Martial Adept
   cost: 4
   description: |-
     You have martial training that allows you to perform a special combat maneuver. You gain the following benefits:
     - You learn one maneuver of your choice from the fighter class.
     - If you don't already have a maneuver die, your maneuver die is a d4, and you can only use your chosen maneuver a number of times equal to your proficiency bonus. You regain expended uses when you finish a short rest or long rest.
+  name: Martial Adept
 mobile:
-  name: Mobile
   cost: 3
   description: |-
     You are exceptionally speedy and agile. You gain the following benefits:
     - Your speed increases by 10 feet.
     - When you use the Dash action, you gain the benefits of the Disengage action, and difficult terrain doesn't cost you extra movement on that turn.
+  name: Mobile
 moderately_armored:
-  name: Moderately Armored
   cost: 2
-  prerequisite: Proficiency with light armor
   description: |-
     You gain proficiency with medium armor and shields.
+  name: Moderately Armored
+  prerequisite: Proficiency with light armor
 powerful_build:
-  name: Powerful Build
   cost: 2
-  prerequisite: Strength 2 or higher
   description: |-
     You are unusually bulky. You count as one size larger than your actual size for the purpose of grappling and being grappled, wielding heavy weapons, determining your carrying capacity, and determining the weight you can push, drag, or lift.
+  name: Powerful Build
+  prerequisite: Strength 2 or higher
 ritual_caster:
-  name: Ritual Caster
   cost: 3
-  prerequisite: Intelligence or Wisdom 1 or higher
   description: |-
     You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.
 
     When you choose this feat, you acquire a ritual book holding two 1st-level spells of your choice. Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You must choose your spells from that class's spell list, and the spells you choose must have the ritual tag. The class you choose also determines your spellcasting ability for these spells: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.
 
     If you come across a spell in written form, such as a magical spell scroll or a wizard's spellbook, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell's level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell into your ritual book takes 2 hours per level of the spell, and costs 50 gp per level. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it.
+  name: Ritual Caster
+  prerequisite: Intelligence or Wisdom 1 or higher
 resilient:
-  name: Resilient
   cost: 3
   description: |-
     Choose one ability score. You gain proficiency in saving throws using the chosen ability.
+  name: Resilient
 spell_sniper:
-  name: Spell Sniper
   cost: 4
-  prerequisite: The ability to cast at least one spell
   description: |-
     You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:
     - When you cast a spell that requires you to make an attack roll, the spell's range is doubled.
     - Your ranged spell attacks ignore half cover and three-quarters cover.
     - You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose from: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.
+  name: Spell Sniper
+  prerequisite: The ability to cast at least one spell
 skilled:
-  name: Skilled
   cost: 2
   description: |-
     You gain proficiency in any combination of three skills or tools of your choice.
+  name: Skilled
 weapons_generalist:
-  name: Weapons Generalist
   cost: 1
   description: |-
     You have practiced with a variety of weapons. You gain proficiency with all simple and martial weapons.
+  name: Weapons Generalist

--- a/feats.yml
+++ b/feats.yml
@@ -34,10 +34,7 @@ expert:
   name: Expert
 frightening:
   cost: 2
-  description: |-
-    You are especially menacing. When you take the Frighten action, you gain the following benefits:
-    - You can target any number of creatures within range and within 20 feet of each other.
-    - Instead of rolling for the Frighten DC, you can use your passive Intimidation. If you do so, the duration of the effect is save ends.
+  description: You are especially menacing. When you take the Frighten action, you can target any number of creatures within range and within 20 feet of each other. When you do so, the saving throw DC to resist being frightened is your passive Intimidation.
   name: Frightening
   prerequisite: Proficiency in Intimidation
 gladiator:
@@ -54,10 +51,7 @@ heavily_armored:
   prerequisite: Proficiency with medium armor
 infuriating:
   cost: 2
-  description: |-
-    You are especially irritating. When you take the Taunt action, you gain the following benefits:
-    - You can target any number of creatures within range and within 20 feet of each other.
-    - Instead of rolling for the Taunt DC, you can use your passive Deception, Performance, or Persuasion. If you do so, the duration of the effect is save ends
+  description: You are especially irritating. When you take the Taunt action, you can target any number of creatures within range and within 20 feet of each other. When you do so, the saving throw DC to resist being taunted is your passive Deception, Performance, or Persuasion (your choice).
   name: Infuriating
   prerequisite: Proficiency in Deception, Performance, or Persuasion
 keen_mind:


### PR DESCRIPTION
I updated my conversion script to include feats, so here's the port. There are a few things that I possibly should not have included, as they aren't 2D standard:
- Sharp Senses references passive perception falloff (see [Perception](https://dnd.mostlymarble.com/rules/2d/glossary/skills.html#perception))
- Gladiator and the armor proficiency feats reflect [shield tiering](https://dnd.mostlymarble.com/rules/2d/player-options/equipment.html#shields) into light, medium, and heavy shield proficiencies
- Linguist references Intelligence checks made to understand other languages and dialects, which is mostly a [4C languages](https://dnd.mostlymarble.com/settings/four-corners/player-options/languages.html) thing
- Brawler mentions the "[grapple](https://dnd.mostlymarble.com/rules/2d/player-options/equipment.html#grapple) attack", which still isn't fully standardized